### PR TITLE
build: Setup Craft to deploy the toolbar into gcs & the CDN

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,0 +1,14 @@
+github:
+  owner: getsentry
+  repo: sentry-toolbar
+preReleaseCommand: bash bin/bump-version.sh
+targets:
+  # CDN Bundle Target
+  - name: gcs
+    id: 'browser-cdn-bundles'
+    includeNames: /.*\.js.*$/
+    bucket: sentry-js-sdk
+    paths:
+      - path: /toolbar/
+        metadata:
+          cacheControl: 'public, max-age=31536000'

--- a/.craft.yml
+++ b/.craft.yml
@@ -9,6 +9,6 @@ targets:
     includeNames: /.*\.js.*$/
     bucket: sentry-js-sdk
     paths:
-      - path: /toolbar/
+      - path: /sentry-toolbar/
         metadata:
           cacheControl: 'public, max-age=31536000'

--- a/.github/workflows/merge-jobs.yml
+++ b/.github/workflows/merge-jobs.yml
@@ -58,3 +58,10 @@ jobs:
 
       - name: Build
         run: pnpm run build
+
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.sha }}
+          path: |
+            ${{ github.workspace }}/packages/browser/build/bundles/**

--- a/.github/workflows/merge-jobs.yml
+++ b/.github/workflows/merge-jobs.yml
@@ -58,9 +58,3 @@ jobs:
 
       - name: Build
         run: pnpm run build
-
-#      TODO: Publish with Craft to the CDN
-#      - name: Publish NPM package
-#        uses: JS-DevTools/npm-publish@v3
-#        with:
-#          token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release
+        required: true
+        default: '1.0.0'
+      force:
+        description: Force a release even when there are release-blockers (optional)
+        required: false
+        default: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: 'Release a new version'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_RELEASE_PAT }}
+          fetch-depth: 0
+
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
+        with:
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Get the code and setup your env:
 If you have your own app and you want to install the toolbar into it follow these steps:
 
 1. Run `pnpm dev` - Builds the library and starts a local webserver to serve it.
-2. Add `<script src="http://localhost:8080/index.iife.js">` to your app.
+2. Add `<script src="http://localhost:8080/index.min.js">` to your app.
 3. Configure the SDK in your app with `<script>window.SentryToolbar.init({...})</script>`.
 
 __Be aware that the usual hot-reload of your app will not apply to the toolbar library. Type CTRL+R or CMD+R to reload your app and pull down new toolbar code.__
@@ -46,7 +46,7 @@ A storybook is available by running: `pnpm start:docs` and is published to https
 ## Production
 
 In production you need to do two things to get the toolbar working:
-1. Add or dynamically inject `<script src="http://<THE CDN>/index.iife.js">` into your app
+1. Add or dynamically inject `<script src="https://browser.sentry-cdn.com/sentry-toolbar/index.min.js">` into your app
 2. Call `window.SentryToolbar.init(initProps)` to setup a toolbar instance.
 
 ### Deploy targets

--- a/bin/bump-version.sh
+++ b/bin/bump-version.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+### Example of a version-bumping script for an NPM project.
+### Located at: ./bin/bump-version.sh
+set -eux
+OLD_VERSION="${1}"
+NEW_VERSION="${2}"
+
+# Do not tag and commit changes made by "npm version"
+export npm_config_git_tag_version=false
+npm version "${NEW_VERSION}"

--- a/docs/conditional-script.md
+++ b/docs/conditional-script.md
@@ -32,11 +32,11 @@ export async function loadToolbar(signal: AbortSignal, cdn: string): Promise<Sen
     return existing;
   }
 
-  await lazyLoad(signal, cdn, 'index.iife.js');
+  await lazyLoad(signal, cdn, 'index.min.js');
 
   const toolbarModule = getWindow().SentryToolbar;
   if (!toolbarModule) {
-    throw new Error(`Could not load integration: index.iife.js`);
+    throw new Error(`Could not load integration: index.min.js`);
   }
 
   return toolbarModule;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,7 +32,8 @@ export default defineConfig({
       entry: resolve(__dirname, 'src/lib/index.ts'),
       name: 'SentryToolbar',
       formats: ['iife'],
-      fileName: 'index',
+      // Implement a custom filename to remove the `iife` suffix
+      fileName: (format, entryName) => 'index.min.js',
     },
     rollupOptions: {
       output: {


### PR DESCRIPTION
The CDN bundle for a JS SDK release is something like: https://browser.sentry-cdn.com/8.32.0/bundle.tracing.replay.min.js`

So for the toolbar is should be something like: `https://browser.sentry-cdn.com/sentry-toolbar/index.min.js`