### PR TITLE
chore: Allow overriding default toolbar config with .env files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+VITE_SENTRY_TOOLBAR_DEBUG=true
+
+# Defaults when using `pnpm dev:standalone`
+VITE_SENTRY_ORIGIN=http://localhost:8080
+VITE_SENTRY_REGION=
+VITE_SENTRY_ORGANIZATION=sentry
+VITE_SENTRY_PROJECT=internal
+VITE_SENTRY_ENVIRONMENT=

--- a/README.md
+++ b/README.md
@@ -18,18 +18,20 @@ Get the code and setup your env:
 
 If you have your own app and you want to install the toolbar into it follow these steps:
 
-1. Run `pnpm dev` - Builds the library and starts a local webserver to serve it.
-2. Add `<script src="http://localhost:8080/toolbar.min.js">` to your app.
-3. Configure the SDK in your app with `<script>window.SentryToolbar.init({...})</script>`.
+1. Create a `.env.local` file, based on `.env.example`.
+2. Run `pnpm dev` - Builds the library and starts a local webserver to serve it.
+3. Add `<script src="http://localhost:8080/toolbar.min.js">` to your app.
+4. Configure the SDK in your app with `<script>window.SentryToolbar.init({...})</script>`.
 
 __Be aware that the usual hot-reload of your app will not apply to the toolbar library. Type CTRL+R or CMD+R to reload your app and pull down new toolbar code.__
 
 If you want to use the bundled sample app, follow these steps:
-
-1. Run `pnpm dev` - Builds the library and starts a local webserver to serve it.
-2. Edit `src/env/demo/App.tsx` to configure the toolbar for your Sentry organization.
-3. Run `pnpm dev:standalone` - Run the sample app.
-4. Visit `http://localhost:5173/` in your browser.
+1. Remove/replace your .env.local file with .env.example.
+    - The default .env values are configured to work with the standalone dev server.
+2. Run `pnpm dev` - Builds the library and starts a local webserver to serve it.
+3. Edit `src/env/demo/App.tsx` to configure the toolbar for your Sentry organization.
+4. Run `pnpm dev:standalone` - Run the sample app.
+5. Visit `http://localhost:5173/` in your browser.
 
 Note that `pnpm dev` is a convenience for running `pnpm dev:watch` & `pnpm dev:server` in parallel.
   - `pnpm dev:watch` rebuilds the library on code changes.

--- a/src/env/demo/App.tsx
+++ b/src/env/demo/App.tsx
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-relative-import-paths/no-relative-import-paths
-import './index.css';
+import 'toolbar/../env/demo/index.css';
 
 import {useEffect} from 'react';
 import * as SentryToolbar from 'toolbar/index';
@@ -10,22 +9,25 @@ export default function App() {
       // InitProps
       mountPoint: document.body,
 
-      // ConnectionConfig
-      sentryOrigin: 'http://localhost:8080',
-      sentryRegion: undefined,
+      // ConnectionConfig -> See .env.example for defaults
+      sentryOrigin: import.meta.env.VITE_SENTRY_ORIGIN ?? 'http://localhost:8080',
+      sentryRegion: import.meta.env.VITE_SENTRY_REGION ?? undefined,
 
       // FeatureFlagsConfig
       featureFlags: undefined,
 
-      // OrgConfig
-      organizationIdOrSlug: 'sentry',
-      projectIdOrSlug: 'javascript',
-      environment: ['prod'],
+      // OrgConfig  -> See .env.example for defaults
+      organizationIdOrSlug: import.meta.env.VITE_SENTRY_ORGANIZATION ?? 'sentry',
+      projectIdOrSlug: import.meta.env.VITE_SENTRY_PROJECT ?? 'internal',
+      environment: [import.meta.env.VITE_SENTRY_ENVIRONMENT],
 
       // RenderConfig
       domId: 'sentry-toolbar',
       placement: 'right-edge',
       theme: 'light',
+
+      // Debug
+      debug: import.meta.env.VITE_SENTRY_TOOLBAR_DEBUG === 'true',
     });
   }, []);
 

--- a/src/lib/utils/ApiProxy.spec.ts
+++ b/src/lib/utils/ApiProxy.spec.ts
@@ -105,7 +105,7 @@ describe('IFrameProxy', () => {
       // @ts-expect-error: Accessing a private method
       expect(removeEventListener).toHaveBeenCalledWith('message', proxy._handlePortMessage);
       expect(close).toHaveBeenCalled();
-      expect(callback).toHaveBeenCalledWith('logged-out');
+      expect(callback).toHaveBeenCalledWith('connecting');
     });
   });
 

--- a/src/lib/utils/ApiProxy.ts
+++ b/src/lib/utils/ApiProxy.ts
@@ -62,7 +62,7 @@ export default class ApiProxy {
     this._port?.removeEventListener('message', this._handlePortMessage);
     this._port?.close();
     this._port = undefined;
-    this._updateStatus('logged-out');
+    this._updateStatus('connecting');
   }
 
   private _updateStatus(state: ProxyState) {


### PR DESCRIPTION
Docs for .env files are: https://vite.dev/guide/env-and-mode

Now you can make your own `.env.local` file then restart the server. This makes it easier to point to different sentry api backends for testing different api responses.