### PR TITLE
fix: Extract use*OnProxyStateChange hooks and fix Navigate conditions

### DIFF
--- a/src/lib/components/AppRouter.tsx
+++ b/src/lib/components/AppRouter.tsx
@@ -1,7 +1,5 @@
-import {useQueryClient} from '@tanstack/react-query';
-import {useEffect} from 'react';
 import {Fragment} from 'react/jsx-runtime';
-import {Routes, Route, Outlet, useNavigate} from 'react-router-dom';
+import {Routes, Route, Outlet} from 'react-router-dom';
 import DebugState from 'toolbar/components/DebugState';
 import CenterLayout from 'toolbar/components/layouts/CenterLayout';
 import RightEdgeLayout from 'toolbar/components/layouts/RightEdgeLayout';
@@ -12,12 +10,12 @@ import Connecting from 'toolbar/components/unauth/Connecting';
 import InvalidDomain from 'toolbar/components/unauth/InvalidDomain';
 import Login from 'toolbar/components/unauth/Login';
 import MissingProject from 'toolbar/components/unauth/MissingProject';
-import {useApiProxyState} from 'toolbar/context/ApiProxyContext';
+import useClearQueryCacheOnProxyStateChange from 'toolbar/hooks/useClearQueryCacheOnProxyStateChange';
+import useNavigateOnProxyStateChange from 'toolbar/hooks/useNavigateOnProxyStateChange';
 
 export default function AppRouter() {
   useNavigateOnProxyStateChange();
   useClearQueryCacheOnProxyStateChange();
-
   return (
     <Routes>
       <Route
@@ -63,40 +61,4 @@ export default function AppRouter() {
       </Route>
     </Routes>
   );
-}
-
-function useNavigateOnProxyStateChange() {
-  const proxyState = useApiProxyState();
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    switch (proxyState) {
-      case 'connecting':
-        navigate('/connecting');
-        break;
-      case 'logged-out':
-        navigate('/login');
-        break;
-      case 'missing-project':
-        navigate('/missing-project');
-        break;
-      case 'invalid-domain':
-        navigate('/invalid-domain');
-        break;
-      case 'connected':
-        navigate('/');
-    }
-  }, [proxyState, navigate]);
-}
-
-function useClearQueryCacheOnProxyStateChange() {
-  const proxyState = useApiProxyState();
-  const queryClient = useQueryClient();
-
-  useEffect(() => {
-    // If the user becomes logged out then clear the query cache
-    if (proxyState !== 'connected') {
-      queryClient.clear();
-    }
-  }, [proxyState, queryClient]);
 }

--- a/src/lib/hooks/useClearQueryCacheOnProxyStateChange.ts
+++ b/src/lib/hooks/useClearQueryCacheOnProxyStateChange.ts
@@ -1,0 +1,15 @@
+import {useQueryClient} from '@tanstack/react-query';
+import {useEffect} from 'react';
+import {useApiProxyState} from 'toolbar/context/ApiProxyContext';
+
+export default function useClearQueryCacheOnProxyStateChange() {
+  const proxyState = useApiProxyState();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    // If the user becomes logged out then clear the query cache
+    if (proxyState !== 'connected') {
+      queryClient.clear();
+    }
+  }, [proxyState, queryClient]);
+}

--- a/src/lib/hooks/useNavigateOnProxyStateChange.ts
+++ b/src/lib/hooks/useNavigateOnProxyStateChange.ts
@@ -1,0 +1,33 @@
+import {useEffect} from 'react';
+import {useNavigate, useMatch, useLocation} from 'react-router-dom';
+import {useApiProxyState} from 'toolbar/context/ApiProxyContext';
+
+const unauthPaths = ['/connecting', '/login', '/missing-project', '/invalid-domain'];
+
+export default function useNavigateOnProxyStateChange() {
+  const proxyState = useApiProxyState();
+  const location = useLocation();
+  const match = useMatch(location.pathname);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    switch (proxyState) {
+      case 'connecting':
+        navigate('/connecting');
+        break;
+      case 'logged-out':
+        navigate('/login');
+        break;
+      case 'missing-project':
+        navigate('/missing-project');
+        break;
+      case 'invalid-domain':
+        navigate('/invalid-domain');
+        break;
+      case 'connected':
+        if (match && unauthPaths.includes(match.pathname)) {
+          navigate('/');
+        }
+    }
+  }, [proxyState, navigate, match]);
+}


### PR DESCRIPTION
Before we were navigating to `'/'` after any proxyState change or nav, which meant you couldn't actually open up a panel.  Fixed with `if (match && unauthPaths.includes(match.pathname)) {`