### PR TITLE
feat: Improve styles of unauth messages

### DIFF
--- a/src/env/demo/App.tsx
+++ b/src/env/demo/App.tsx
@@ -18,7 +18,7 @@ export default function App() {
 
       // OrgConfig  -> See .env.example for defaults
       organizationSlug: import.meta.env.VITE_SENTRY_ORGANIZATION ?? 'sentry',
-      projectIdOrSlug: import.meta.env.VITE_SENTRY_PROJECT ?? 'internal',
+      projectIdOrSlug: import.meta.env.VITE_SENTRY_PROJECT ?? 'fake',
       environment: [import.meta.env.VITE_SENTRY_ENVIRONMENT],
 
       // RenderConfig

--- a/src/lib/components/AppRouter.tsx
+++ b/src/lib/components/AppRouter.tsx
@@ -8,7 +8,6 @@ import IssuesPanel from 'toolbar/components/panels/issues/IssuesPanel';
 import SettingsPanel from 'toolbar/components/panels/settings/SettingsPanel';
 import Connecting from 'toolbar/components/unauth/Connecting';
 import InvalidDomain from 'toolbar/components/unauth/InvalidDomain';
-import Login from 'toolbar/components/unauth/Login';
 import MissingProject from 'toolbar/components/unauth/MissingProject';
 import useClearQueryCacheOnProxyStateChange from 'toolbar/hooks/useClearQueryCacheOnProxyStateChange';
 import useNavigateOnProxyStateChange from 'toolbar/hooks/useNavigateOnProxyStateChange';
@@ -34,7 +33,7 @@ export default function AppRouter() {
             </CenterLayout>
           }>
           <Route path="/connecting" element={<Connecting />} />
-          <Route path="/login" element={<Login />} />
+          <Route path="/login" element={null /* ApiProxyContextProvider will render the login iframe */} />
           <Route path="/missing-project" element={<MissingProject />} />
           <Route path="/invalid-domain" element={<InvalidDomain />} />
         </Route>

--- a/src/lib/components/unauth/Connecting.tsx
+++ b/src/lib/components/unauth/Connecting.tsx
@@ -1,8 +1,9 @@
 import {useContext} from 'react';
+import UnauthPill from 'toolbar/components/unauth/UnauthPill';
 import ConfigContext from 'toolbar/context/ConfigContext';
 
 export default function Connecting() {
   const {sentryOrigin} = useContext(ConfigContext);
 
-  return <div>Connecting to {sentryOrigin}...</div>;
+  return <UnauthPill>Connecting to {sentryOrigin}...</UnauthPill>;
 }

--- a/src/lib/components/unauth/InvalidDomain.tsx
+++ b/src/lib/components/unauth/InvalidDomain.tsx
@@ -1,3 +1,5 @@
+import UnauthPill from 'toolbar/components/unauth/UnauthPill';
+
 export default function InvalidDomain() {
-  return <div>The domain is invalid or not configured</div>;
+  return <UnauthPill>The domain is invalid or not configured</UnauthPill>;
 }

--- a/src/lib/components/unauth/MissingProject.tsx
+++ b/src/lib/components/unauth/MissingProject.tsx
@@ -1,3 +1,5 @@
+import UnauthPill from 'toolbar/components/unauth/UnauthPill';
+
 export default function MissingProject() {
-  return <div>Missing Project</div>;
+  return <UnauthPill>Missing Project</UnauthPill>;
 }

--- a/src/lib/components/unauth/UnauthPill.tsx
+++ b/src/lib/components/unauth/UnauthPill.tsx
@@ -1,12 +1,16 @@
 import IconSentry from 'toolbar/components/icon/IconSentry';
 
-export default function Login() {
+interface Props {
+  children: React.ReactNode;
+}
+
+export default function UnauthPill({children}: Props) {
   return (
     <div className="flex translate-y-[30vh] flex-row place-items-center gap-1 rounded-full bg-black-raw p-px px-2 text-sm text-white-raw">
       <span title="sentry.io">
         <IconSentry size="md" />
       </span>
-      {/* TODO: login button is inside the iframe, we need to render it in position */}
+      {children}
     </div>
   );
 }

--- a/src/lib/context/ApiProxyContext.tsx
+++ b/src/lib/context/ApiProxyContext.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable react-refresh/only-export-components */
 import {createContext, useCallback, useContext, useEffect, useRef, useState} from 'react';
 import type {ReactNode} from 'react';
+import CenterLayout from 'toolbar/components/layouts/CenterLayout';
+import UnauthPill from 'toolbar/components/unauth/UnauthPill';
 import ConfigContext from 'toolbar/context/ConfigContext';
 import defaultConfig from 'toolbar/context/defaultConfig';
 import {getSentryWebUrl} from 'toolbar/sentryApi/urls';
@@ -48,7 +50,15 @@ export function ApiProxyContextProvider({children}: Props) {
   return (
     <ApiProxyContext.Provider value={proxyRef.current}>
       <ApiProxyStateContext.Provider value={proxyState}>
-        <iframe referrerPolicy="origin" height="200" width="400" src={frameSrc} style={{display}} ref={iframeRef} />
+        <div style={{display}}>
+          <CenterLayout>
+            <CenterLayout.MainArea>
+              <UnauthPill>
+                <iframe referrerPolicy="origin" height="40" width="80" src={frameSrc} ref={iframeRef} />
+              </UnauthPill>
+            </CenterLayout.MainArea>
+          </CenterLayout>
+        </div>
         {children}
       </ApiProxyStateContext.Provider>
     </ApiProxyContext.Provider>


### PR DESCRIPTION
Login looks like this, passing through to the iframe:
<img width="208" alt="SCR-20241009-pysb" src="https://github.com/user-attachments/assets/ffa84026-8dd9-47d5-b1e8-9be11cdea91c">


And messages are looking like this so far:
<img width="201" alt="SCR-20241009-pymq" src="https://github.com/user-attachments/assets/6202c883-eefa-435f-8e66-6afd6deb5139">
