### PR TITLE
fix: Dont use region subdomain api origins

### DIFF
--- a/src/lib/sentryApi/urls.spec.ts
+++ b/src/lib/sentryApi/urls.spec.ts
@@ -24,26 +24,26 @@ describe('getSentryApiUrl', () => {
       },
       'https://acme.sentry.io/api/0/',
     ],
-    [
-      'SaaS config: root, insert region',
-      {
-        sentryOrigin: 'https://sentry.io',
-        sentryRegion: 'us',
-        sentryApiPath: '/api/0/',
-        organizationSlug: 'acme',
-      },
-      'https://acme.sentry.io/region/us/api/0/',
-    ],
-    [
-      'SaaS config: subdomain, replace with region',
-      {
-        sentryOrigin: 'https://acme.sentry.io',
-        sentryRegion: 'us',
-        sentryApiPath: '/api/0/',
-        organizationSlug: 'acme',
-      },
-      'https://acme.sentry.io/region/us/api/0/',
-    ],
+    // [
+    //   'SaaS config: root, insert region',
+    //   {
+    //     sentryOrigin: 'https://sentry.io',
+    //     sentryRegion: 'us',
+    //     sentryApiPath: '/api/0/',
+    //     organizationSlug: 'acme',
+    //   },
+    //   'https://acme.sentry.io/region/us/api/0/',
+    // ],
+    // [
+    //   'SaaS config: subdomain, replace with region',
+    //   {
+    //     sentryOrigin: 'https://acme.sentry.io',
+    //     sentryRegion: 'us',
+    //     sentryApiPath: '/api/0/',
+    //     organizationSlug: 'acme',
+    //   },
+    //   'https://acme.sentry.io/region/us/api/0/',
+    // ],
     [
       'sentry devserver config',
       {

--- a/src/lib/sentryApi/urls.ts
+++ b/src/lib/sentryApi/urls.ts
@@ -17,7 +17,7 @@ function isSaasOriginWithSubdomain(hostname: string) {
  * Given a configuration, we want to return the base URL for API calls
  */
 export function getSentryApiUrl(config: Configuration) {
-  const {organizationSlug, sentryOrigin, sentryRegion, sentryApiPath} = config;
+  const {organizationSlug, sentryOrigin, sentryApiPath} = config;
 
   const origin = getOrigin(sentryOrigin);
   if (!origin) {
@@ -27,11 +27,16 @@ export function getSentryApiUrl(config: Configuration) {
   const parts = [origin.protocol, '//'];
 
   if (isSaasOriginWithSubdomain(origin.hostname) || origin.hostname === 'sentry.io') {
-    if (sentryRegion) {
-      parts.push(`${organizationSlug}.sentry.io/region/${sentryRegion}`);
-    } else {
-      parts.push(`${organizationSlug}.sentry.io`);
-    }
+    // TODO: Wew should be setting cookies on sentry.io, not just the subdomain
+    // Then we'll be able to use the region subdomains for faster API requests
+    // But, for now org subdomains are fine.
+    parts.push(`${organizationSlug}.sentry.io`);
+
+    // if (sentryRegion) {
+    //   parts.push(`${sentryRegion}.sentry.io`);
+    // } else {
+    //   parts.push(`${organizationSlug}.sentry.io`);
+    // }
   } else {
     parts.push(origin.hostname);
   }


### PR DESCRIPTION
The comment in the code also says it... but the /iframe/ view is setting our cookie into an origin that includes the org-subdomain. so like `document.cookie = 'sid=123; domain=acme.sentry.io`

Therefore we don't have auth when we try to use a region-subdomain like `us.sentry.io` for the api calls.
The result is slower api calls because the server will need to sort out which region to use, and jump over to it. We can fix this in the future though.