### PR TITLE
ref: IconLock doesnt have a solid state

### DIFF
--- a/src/lib/components/icon/IconLock.tsx
+++ b/src/lib/components/icon/IconLock.tsx
@@ -3,7 +3,6 @@ import SVGIconBase from 'toolbar/components/icon/SVGIconBase';
 import type {SVGIconProps} from 'toolbar/components/icon/SVGIconBase';
 
 interface Props extends SVGIconProps {
-  isSolid?: boolean;
   isLocked?: boolean;
 }
 


### PR DESCRIPTION
Same as in https://github.com/getsentry/sentry/pull/79938, which is the source of this icon file.