### PR TITLE
fix: Explicitly ask for te non-subdomain origin when loading the toolbar login-sucess popup

### DIFF
--- a/mock/server/public/toolbar/iframe.html
+++ b/mock/server/public/toolbar/iframe.html
@@ -24,8 +24,12 @@
         }
 
         function requestAuthn(delay_ms) {
+          const origin = window.location.origin.endsWith('.sentry.io')
+            ? 'https://sentry.io'
+            : window.location.origin;
+
           window.open(
-            `/toolbar/${organizationSlug}/${projectIdOrSlug}/login-success/?delay=${delay_ms ?? '0'}`,
+            `${origin}/toolbar/${organizationSlug}/${projectIdOrSlug}/login-success/?delay=${delay_ms ?? '0'}`,
             'sentry-toolbar-auth-popup',
             'popup=true,innerWidth=800,innerHeight=550,noopener=false'
           );

--- a/mock/server/public/toolbar/login-success.html
+++ b/mock/server/public/toolbar/login-success.html
@@ -22,16 +22,12 @@
         });
 
         if (window.opener) {
-          const origin = window.location.origin.endsWith('.sentry.io')
-            ? 'https://sentry.io'
-            : window.location.origin;
-
           window.opener.postMessage({
             source: 'sentry-toolbar',
             message: 'did-login',
             cookie,
             token,
-          }, origin);
+          }, window.location.origin);
 
           if (delay && typeof delay === 'number') {
             setTimeout(() => {

--- a/src/lib/context/__mocks__/defaultConfig.ts
+++ b/src/lib/context/__mocks__/defaultConfig.ts
@@ -4,7 +4,7 @@ const defaultConfig: Configuration = {
   // ConnectionConfig
   sentryOrigin: 'https://sentry.io',
   sentryRegion: 'us',
-  sentryApiPath: undefined,
+  sentryApiPath: '/api/0',
 
   // FeatureFlagsConfig
   featureFlags: undefined,

--- a/src/lib/hooks/fetch/useSentryApi.ts
+++ b/src/lib/hooks/fetch/useSentryApi.ts
@@ -2,7 +2,7 @@ import qs from 'query-string';
 import {useContext, useMemo} from 'react';
 import {useApiProxyInstance} from 'toolbar/context/ApiProxyContext';
 import ConfigContext from 'toolbar/context/ConfigContext';
-import {getSentryApiOrigin} from 'toolbar/sentryApi/urls';
+import {getSentryApiBaseUrl} from 'toolbar/sentryApi/urls';
 import type {ApiEndpointQueryKey, ApiResult} from 'toolbar/types/api';
 import parseLinkHeader from 'toolbar/utils/parseLinkHeader';
 import type {ParsedHeader} from 'toolbar/utils/parseLinkHeader';
@@ -31,12 +31,12 @@ export default function useSentryApi<Data>() {
   const apiProxy = useApiProxyInstance();
   const config = useContext(ConfigContext);
 
-  const apiOrigin = getSentryApiOrigin(config);
+  const apiBaseUrl = getSentryApiBaseUrl(config);
 
   const fetchFn = useMemo(
     () =>
       async ({/* signal, */ queryKey: [endpoint, options]}: FetchParams): Promise<ApiResult<Data>> => {
-        const url = qs.stringifyUrl({url: apiOrigin + endpoint, query: options?.query});
+        const url = qs.stringifyUrl({url: apiBaseUrl + endpoint, query: options?.query});
         const contentType = options?.payload ? {'Content-Type': 'application/json'} : {};
         const init = {
           body: options?.payload ? JSON.stringify(options?.payload) : undefined,
@@ -63,7 +63,7 @@ export default function useSentryApi<Data>() {
         }
         return apiResult;
       },
-    [apiOrigin, apiProxy]
+    [apiBaseUrl, apiProxy]
   );
 
   const fetchInfiniteFn = useMemo(

--- a/src/lib/sentryApi/urls.spec.ts
+++ b/src/lib/sentryApi/urls.spec.ts
@@ -1,11 +1,11 @@
 import defaultConfig from 'toolbar/context/defaultConfig';
-import {getSentryApiOrigin, getSentryWebOrigin, getSentryIFrameOrigin} from 'toolbar/sentryApi/urls';
+import {getSentryApiBaseUrl, getSentryWebOrigin, getSentryIFrameOrigin} from 'toolbar/sentryApi/urls';
 import type {Configuration} from 'toolbar/types/config';
 
 type TestCase = [
   string,
   Partial<Configuration>,
-  {getSentryApiOrigin: string; getSentryWebOrigin: string; getSentryIFrameOrigin: string},
+  {getSentryApiBaseUrl: string; getSentryWebOrigin: string; getSentryIFrameOrigin: string},
 ];
 const testCases: TestCase[] = [
   [
@@ -17,9 +17,9 @@ const testCases: TestCase[] = [
       organizationSlug: 'acme',
     },
     {
-      getSentryApiOrigin: 'https://acme.sentry.io/api/0/',
+      getSentryApiBaseUrl: 'https://acme.sentry.io/api/0/',
       getSentryWebOrigin: 'https://acme.sentry.io',
-      getSentryIFrameOrigin: 'https://sentry.io',
+      getSentryIFrameOrigin: 'https://acme.sentry.io',
     },
   ],
   [
@@ -31,9 +31,9 @@ const testCases: TestCase[] = [
       organizationSlug: 'acme',
     },
     {
-      getSentryApiOrigin: 'https://acme.sentry.io/api/0/',
+      getSentryApiBaseUrl: 'https://acme.sentry.io/api/0/',
       getSentryWebOrigin: 'https://acme.sentry.io',
-      getSentryIFrameOrigin: 'https://sentry.io',
+      getSentryIFrameOrigin: 'https://acme.sentry.io',
     },
   ],
   [
@@ -45,9 +45,9 @@ const testCases: TestCase[] = [
       organizationSlug: 'acme',
     },
     {
-      getSentryApiOrigin: 'https://acme.sentry.io/region/us/api/0/',
+      getSentryApiBaseUrl: 'https://acme.sentry.io/region/us/api/0/',
       getSentryWebOrigin: 'https://acme.sentry.io',
-      getSentryIFrameOrigin: 'https://sentry.io',
+      getSentryIFrameOrigin: 'https://acme.sentry.io',
     },
   ],
   [
@@ -59,9 +59,9 @@ const testCases: TestCase[] = [
       organizationSlug: 'acme',
     },
     {
-      getSentryApiOrigin: 'https://acme.sentry.io/region/us/api/0/',
+      getSentryApiBaseUrl: 'https://acme.sentry.io/region/us/api/0/',
       getSentryWebOrigin: 'https://acme.sentry.io',
-      getSentryIFrameOrigin: 'https://sentry.io',
+      getSentryIFrameOrigin: 'https://acme.sentry.io',
     },
   ],
   [
@@ -73,7 +73,7 @@ const testCases: TestCase[] = [
       organizationSlug: 'acme',
     },
     {
-      getSentryApiOrigin: 'https://dev.getsentry.net:8000/api/0',
+      getSentryApiBaseUrl: 'https://dev.getsentry.net:8000/api/0',
       getSentryWebOrigin: 'https://dev.getsentry.net:8000',
       getSentryIFrameOrigin: 'https://dev.getsentry.net:8000',
     },
@@ -87,7 +87,7 @@ const testCases: TestCase[] = [
       organizationSlug: 'acme',
     },
     {
-      getSentryApiOrigin: 'https://dev.getsentry.net:8000/api/0',
+      getSentryApiBaseUrl: 'https://dev.getsentry.net:8000/api/0',
       getSentryWebOrigin: 'https://dev.getsentry.net:8000',
       getSentryIFrameOrigin: 'https://dev.getsentry.net:8000',
     },
@@ -101,16 +101,16 @@ const testCases: TestCase[] = [
       organizationSlug: 'acme',
     },
     {
-      getSentryApiOrigin: 'http://localhost:8080/api/0',
+      getSentryApiBaseUrl: 'http://localhost:8080/api/0',
       getSentryWebOrigin: 'http://localhost:8080',
       getSentryIFrameOrigin: 'http://localhost:8080',
     },
   ],
 ];
 
-describe('getSentryApiOrigin', () => {
+describe('getSentryApiBaseUrl', () => {
   it.each<TestCase>(testCases)('should get the correct url for api requests: %s', (_title, config, expected) => {
-    expect(getSentryApiOrigin({...defaultConfig, ...config})).toBe(expected.getSentryApiOrigin);
+    expect(getSentryApiBaseUrl({...defaultConfig, ...config})).toBe(expected.getSentryApiBaseUrl);
   });
 });
 

--- a/src/lib/sentryApi/urls.ts
+++ b/src/lib/sentryApi/urls.ts
@@ -19,7 +19,7 @@ function isSaasOrigin(hostname: string) {
 /**
  * Given a configuration, we want to return the base URL for API calls
  */
-export function getSentryApiOrigin(config: Configuration) {
+export function getSentryApiBaseUrl(config: Configuration) {
   const {organizationSlug, sentryOrigin, sentryRegion, sentryApiPath} = config;
 
   const origin = getOrigin(sentryOrigin);
@@ -57,6 +57,9 @@ export function getSentryApiOrigin(config: Configuration) {
   return parts.join('');
 }
 
+/**
+ * Returns an origin with organization subdomain included, if SaaS is detected.
+ */
 export function getSentryWebOrigin(config: Configuration) {
   const {sentryOrigin, organizationSlug} = config;
 
@@ -70,15 +73,9 @@ export function getSentryWebOrigin(config: Configuration) {
   return sentryOrigin;
 }
 
+/**
+ * Defer to getSentryWebOrigin()
+ */
 export function getSentryIFrameOrigin(config: Configuration) {
-  const {sentryOrigin} = config;
-
-  const origin = getOrigin(sentryOrigin);
-  if (!origin) {
-    return sentryOrigin;
-  }
-  if (isSaasOrigin(origin.hostname)) {
-    return `https://sentry.io`;
-  }
-  return sentryOrigin;
+  return getSentryWebOrigin(config);
 }

--- a/src/lib/utils/ApiProxy.spec.ts
+++ b/src/lib/utils/ApiProxy.spec.ts
@@ -1,4 +1,5 @@
 import defaultConfig from 'toolbar/context/defaultConfig';
+import {getSentryIFrameOrigin} from 'toolbar/sentryApi/urls';
 import ApiProxy from 'toolbar/utils/ApiProxy';
 
 jest.mock('toolbar/context/defaultConfig');
@@ -8,7 +9,7 @@ describe('ApiProxy', () => {
     // @ts-expect-error: Accessing a private method
     const handleWindowMessage = proxy._handleWindowMessage;
     // @ts-expect-error: Accessing a private member
-    const expectedOrigin = proxy._config.sentryOrigin;
+    const expectedOrigin = getSentryIFrameOrigin(proxy._config);
     // @ts-expect-error: This is an incomplete mock
     handleWindowMessage({origin: expectedOrigin, data, ports});
   }

--- a/src/lib/utils/ApiProxy.ts
+++ b/src/lib/utils/ApiProxy.ts
@@ -120,7 +120,7 @@ export default class ApiProxy {
       return; // MessageEvent is malformed without an $id
     }
     if (!this._promiseMap.has($id)) {
-      this.log('message already handled', $id, Array.from(this._promiseMap.entries()));
+      this.log('message already handled', $id, {_promiseMap: Array.from(this._promiseMap.entries())});
       return; // Message was handled already?
     }
 
@@ -146,7 +146,11 @@ export default class ApiProxy {
     return new Promise((resolve, reject) => {
       const $id = ++this._sequence;
       this._promiseMap.set($id, [resolve, reject]);
-      this.log('port.postMessage() => ', {$id, message, transfer}, Array.from(this._promiseMap.entries()));
+      this.log(
+        'port.postMessage() => ',
+        {$id, message, transfer},
+        {_promiseMap: Array.from(this._promiseMap.entries())}
+      );
 
       signal.addEventListener(
         'abort',


### PR DESCRIPTION
This is to keep templates up to date with https://github.com/getsentry/sentry/pull/80003 and also fix the urls so that we're using subdomains most of the time with sentry saas.