### PR TITLE
ref: Remove unused form/button, prefer the request-authn command instead

### DIFF
--- a/mock/server/public/toolbar/iframe.html
+++ b/mock/server/public/toolbar/iframe.html
@@ -5,10 +5,6 @@
     <link rel="icon" href="data:;base64,iVBORw0KGgo=">
   </head>
   <body>
-    <form id="login-form">
-      <button type="submit">Log in</button>
-    </form>
-
     <script>
       (function() {
         const referrer = __REFERRER__;
@@ -33,15 +29,6 @@
             'sentry-toolbar-auth-popup',
             'popup=true,innerWidth=800,innerHeight=550,noopener=false'
           );
-        }
-
-        function setupLoginForm() {
-          log('setupLoginForm()');
-          const form = document.getElementById('login-form');
-          form.addEventListener('submit', submitEvent => {
-            submitEvent.preventDefault();
-            requestAuthn();
-          });
         }
 
         function sendStateMessage(state) {
@@ -163,7 +150,6 @@
         log('Init', { referrer, state });
 
         setupMessageChannel();
-        setupLoginForm();
         listenForLoginSuccess();
         // enum of: logged-out, missing-project, invalid-domain, logged-in
         sendStateMessage(state === 'success' ? 'logged-in' : state);

--- a/src/lib/components/AppRouter.tsx
+++ b/src/lib/components/AppRouter.tsx
@@ -13,9 +13,6 @@ import MissingProject from 'toolbar/components/unauth/MissingProject';
 import useClearQueryCacheOnProxyStateChange from 'toolbar/hooks/useClearQueryCacheOnProxyStateChange';
 import useNavigateOnProxyStateChange from 'toolbar/hooks/useNavigateOnProxyStateChange';
 
-// If the iframe is visible, then we'll let ApiProxyContextProvider render the login button
-const VISIBLE_IFRAME = localStorage.getItem('sntry_tlbr__visible_iframe') ?? false;
-
 export default function AppRouter() {
   useNavigateOnProxyStateChange();
   useClearQueryCacheOnProxyStateChange();
@@ -37,7 +34,7 @@ export default function AppRouter() {
             </CenterLayout>
           }>
           <Route path="/connecting" element={<Connecting />} />
-          <Route path="/login" element={VISIBLE_IFRAME ? null : <Login />} />
+          <Route path="/login" element={<Login />} />
           <Route path="/missing-project" element={<MissingProject />} />
           <Route path="/invalid-domain" element={<InvalidDomain />} />
         </Route>

--- a/src/lib/context/ApiProxyContext.tsx
+++ b/src/lib/context/ApiProxyContext.tsx
@@ -1,8 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 import {createContext, useCallback, useContext, useEffect, useRef, useState} from 'react';
 import type {ReactNode} from 'react';
-import CenterLayout from 'toolbar/components/layouts/CenterLayout';
-import UnauthPill from 'toolbar/components/unauth/UnauthPill';
 import ConfigContext from 'toolbar/context/ConfigContext';
 import defaultConfig from 'toolbar/context/defaultConfig';
 import {getSentryIFrameOrigin} from 'toolbar/sentryApi/urls';
@@ -14,9 +12,6 @@ const ApiProxyContext = createContext<ApiProxy>(new ApiProxy(defaultConfig));
 interface Props {
   children: ReactNode;
 }
-
-// If the iframe is visible, then we'll let ApiProxyContextProvider render the login button
-const VISIBLE_IFRAME = localStorage.getItem('sntry_tlbr__visible_iframe') ?? false;
 
 export function ApiProxyContextProvider({children}: Props) {
   const config = useContext(ConfigContext);
@@ -47,34 +42,14 @@ export function ApiProxyContextProvider({children}: Props) {
 
   const frameSrc = `${getSentryIFrameOrigin(config)}/toolbar/${organizationSlug}/${projectIdOrSlug}/iframe/?logging=${debug ? 1 : 0}`;
 
-  if (VISIBLE_IFRAME) {
-    const display = proxyState === 'logged-out' ? 'block' : 'none';
-    return (
-      <ApiProxyContext.Provider value={proxyRef.current}>
-        <ApiProxyStateContext.Provider value={proxyState}>
-          <div style={{display}}>
-            <CenterLayout>
-              <CenterLayout.MainArea>
-                <UnauthPill>
-                  <iframe referrerPolicy="origin" height="40" width="80" src={frameSrc} />
-                </UnauthPill>
-              </CenterLayout.MainArea>
-            </CenterLayout>
-          </div>
-          {children}
-        </ApiProxyStateContext.Provider>
-      </ApiProxyContext.Provider>
-    );
-  } else {
-    return (
-      <ApiProxyContext.Provider value={proxyRef.current}>
-        <ApiProxyStateContext.Provider value={proxyState}>
-          <iframe referrerPolicy="origin" height="0" width="0" src={frameSrc} className="hidden" />
-          {children}
-        </ApiProxyStateContext.Provider>
-      </ApiProxyContext.Provider>
-    );
-  }
+  return (
+    <ApiProxyContext.Provider value={proxyRef.current}>
+      <ApiProxyStateContext.Provider value={proxyState}>
+        <iframe referrerPolicy="origin" height="0" width="0" src={frameSrc} className="hidden" />
+        {children}
+      </ApiProxyStateContext.Provider>
+    </ApiProxyContext.Provider>
+  );
 }
 
 /**


### PR DESCRIPTION
The production templates are updated in https://github.com/getsentry/sentry/pull/80035 to align with this.

I think that if that production change doesn't land right away, this change will still be safe. The idea is that we are not by default... and now not ever showing the login form. `VISIBLE_IFRAME` is false by default, and now removed.