### PR TITLE
feat(toolbar): Make Issue and Feedback Panels look like Sentry toolbar

### DIFF
--- a/src/lib/components/datetime/RelativeDateTime.tsx
+++ b/src/lib/components/datetime/RelativeDateTime.tsx
@@ -1,9 +1,27 @@
+import type {FormatDistanceToken} from 'date-fns';
 import {formatDistanceToNowStrict} from 'date-fns/formatDistanceToNowStrict';
 
-export default function RelativeDateTime({date}: {date: Date}) {
+export default function RelativeDateTime({date, suffix}: {date: Date; suffix: string}) {
   return (
     <time dateTime={date.toISOString()}>
-      {formatDistanceToNowStrict(date, {addSuffix: true, roundingMethod: 'floor'})}
+      {formatDistanceToNowStrict(date, {
+        addSuffix: true,
+        roundingMethod: 'floor',
+        locale: {
+          formatDistance: (token: FormatDistanceToken, count: number) => {
+            const formatMap: Partial<Record<FormatDistanceToken, string>> = {
+              xSeconds: `${count}s ${suffix}`,
+              xMinutes: `${count}min ${suffix}`,
+              xHours: `${count}hr ${suffix}`,
+              xDays: `${count}d ${suffix}`,
+              xWeeks: `${count}w ${suffix}`,
+              xMonths: `${count}mo ${suffix}`,
+              xYears: `${count}y ${suffix}`,
+            };
+            return formatMap[token] || `${count}d`;
+          },
+        },
+      })}
     </time>
   );
 }

--- a/src/lib/components/datetime/RelativeDateTime.tsx
+++ b/src/lib/components/datetime/RelativeDateTime.tsx
@@ -5,7 +5,6 @@ export default function RelativeDateTime({date, suffix}: {date: Date; suffix: st
   return (
     <time dateTime={date.toISOString()}>
       {formatDistanceToNowStrict(date, {
-        addSuffix: true,
         roundingMethod: 'floor',
         locale: {
           formatDistance: (token: FormatDistanceToken, count: number) => {

--- a/src/lib/components/icon/SVGIconBase.tsx
+++ b/src/lib/components/icon/SVGIconBase.tsx
@@ -3,7 +3,7 @@ import type {SVGAttributes} from 'react';
 import {useIconDefaultsContext} from 'toolbar/context/IconDefaultsContext';
 
 const iconNumberSizes = {
-  xs: 16,
+  xs: 12,
   sm: 16,
   md: 20,
   lg: 24,

--- a/src/lib/components/panels/feedback/FeedbackListItem.tsx
+++ b/src/lib/components/panels/feedback/FeedbackListItem.tsx
@@ -26,13 +26,15 @@ export default function FeedbackListItem({item}: {item: FeedbackIssueListItem}) 
           <FeedbackDates firstSeen={item.firstSeen} />
         </div>
         <FeedbackMessage message={item.metadata.value} />
-        <div className="flex justify-between">
+        <div className="flex items-center justify-between">
           <FeedbackProject item={item} />
-          {hasComments ? <IconChat size="sm" /> : null}
-          {isFatal ? <IconFatal size="xs" color="red400" /> : null}
-          {hasReplayId ? <IconPlay size="xs" /> : null}
-          {hasAttachments ? <IconImage size="xs" /> : null}
-          <FeedbackAssignedTo assignedTo={item.assignedTo} />
+          <div className="flex flex-row justify-between gap-0.5">
+            {hasComments ? <IconChat size="xs" /> : null}
+            {isFatal ? <IconFatal size="xs" color="red400" /> : null}
+            {hasReplayId ? <IconPlay size="xs" /> : null}
+            {hasAttachments ? <IconImage size="xs" /> : null}
+            {item.assignedTo ? <FeedbackAssignedTo assignedTo={item.assignedTo} /> : null}
+          </div>
         </div>
       </div>
     </div>
@@ -54,7 +56,7 @@ function FeedbackType({item}: {item: FeedbackIssueListItem}) {
 function FeedbackDates({firstSeen}: {firstSeen: string}) {
   return (
     <span className="flex items-center gap-0.5 whitespace-nowrap text-xs text-gray-300">
-      <RelativeDateTime date={new Date(firstSeen)} />
+      <RelativeDateTime date={new Date(firstSeen)} suffix="ago" />
     </span>
   );
 }
@@ -68,7 +70,7 @@ function FeedbackProject({item}: {item: FeedbackIssueListItem}) {
 }
 
 function FeedbackAssignedTo({assignedTo}: {assignedTo: GroupAssignedTo | null | undefined}) {
-  return <span className="truncate">{assignedTo?.name.at(0)}</span>;
+  return <span className="truncate text-xs">{assignedTo?.name.at(0)}</span>;
 }
 
 function useReplayCountForFeedbacks(organization: string | number) {

--- a/src/lib/components/panels/feedback/FeedbackPanel.tsx
+++ b/src/lib/components/panels/feedback/FeedbackPanel.tsx
@@ -24,6 +24,9 @@ export default function FeedbackPanel() {
       <h1 className="flex flex-col border-b border-b-translucentGray-200 px-2 py-1">
         <SentryAppLink to={{url: `/feedback/`, query: {project: organizationSlug}}}>User Feedback</SentryAppLink>
       </h1>
+      <div className="mx-1.5 flex flex-col gap-0.25 border-b border-b-translucentGray-200 py-0.75 text-sm font-bold text-gray-300">
+        <span>Unresolved feedback related to this page</span>
+      </div>
 
       <div className="flex grow flex-col">
         <InfiniteListState

--- a/src/lib/components/panels/issues/IssueListItem.tsx
+++ b/src/lib/components/panels/issues/IssueListItem.tsx
@@ -11,7 +11,10 @@ export default function IssueListItem({item}: {item: Group}) {
       <div className="flex flex-col gap-0.25 border-b border-b-translucentGray-200 py-0.75">
         <div className="flex justify-between">
           <IssueType item={item} />
-          <IssueSeenDates firstSeen={item.firstSeen} lastSeen={item.lastSeen} />
+          <IssueSeenDates
+            firstSeen={item.lifetime?.firstSeen || item.firstSeen}
+            lastSeen={item.lifetime?.lastSeen || item.lastSeen}
+          />
         </div>
         <IssueMessage message={item.metadata.value} />
         <div className="flex justify-between">
@@ -38,9 +41,9 @@ function IssueType({item}: {item: Group}) {
 function IssueSeenDates({firstSeen, lastSeen}: {firstSeen: string; lastSeen: string}) {
   return (
     <span className="flex items-center gap-0.5 whitespace-nowrap text-xs text-gray-300">
-      <RelativeDateTime date={new Date(lastSeen)} />
+      <RelativeDateTime date={new Date(lastSeen)} suffix="ago" />
       <span className="font-bold">·</span>
-      <RelativeDateTime date={new Date(firstSeen)} />
+      <RelativeDateTime date={new Date(firstSeen)} suffix="old" />
     </span>
   );
 }
@@ -54,5 +57,5 @@ function IssueProject({item}: {item: Group}) {
 }
 
 function IssueAssignedTo({assignedTo}: {assignedTo: GroupAssignedTo | null | undefined}) {
-  return <span className="truncate">{assignedTo?.name.at(0)}</span>;
+  return <span className="truncate text-xs">{assignedTo?.name.at(0)}</span>;
 }

--- a/src/lib/components/panels/issues/IssuesPanel.tsx
+++ b/src/lib/components/panels/issues/IssuesPanel.tsx
@@ -24,6 +24,9 @@ export default function IssuesPanel() {
       <h1 className="flex flex-col border-b border-b-translucentGray-200 px-2 py-1">
         <SentryAppLink to={{url: `/issues/`, query: {project: organizationSlug}}}>Issues</SentryAppLink>
       </h1>
+      <div className="mx-1.5 flex flex-col gap-0.25 border-b border-b-translucentGray-200 py-0.75 text-sm font-bold text-gray-300">
+        <span>Unresolved issues related to this page</span>
+      </div>
 
       <div className="flex grow flex-col">
         <InfiniteListState


### PR DESCRIPTION
Adds some CSS and formatting stuff to make the issue and feedback panels look like the one on the Sentry toolbar

Issues Panel
<img width="401" alt="image" src="https://github.com/user-attachments/assets/8b1401f7-dc27-4910-8fc3-9067a761d05b">
Feedback Panel
<img width="401" alt="383311017-a712c0a7-f521-44f7-ac0f-bca55a7b6fe2" src="https://github.com/user-attachments/assets/ecd3d8fc-9573-49bd-96a7-610ed5274d1d">

Relates to https://github.com/getsentry/sentry-toolbar/issues/75