### PR TITLE
feat: Update the granularity of debug info

### DIFF
--- a/docs/conditional-script.md
+++ b/docs/conditional-script.md
@@ -136,7 +136,7 @@ function MyReactApp() {
       theme: 'light',
 
       // Debug
-      debug: false,
+      debug: 'false',
     }
   });
 

--- a/src/env/demo/App.tsx
+++ b/src/env/demo/App.tsx
@@ -29,7 +29,7 @@ export default function App() {
       theme: 'light',
 
       // Debug
-      debug: import.meta.env.VITE_SENTRY_TOOLBAR_DEBUG === 'true',
+      debug: import.meta.env.VITE_SENTRY_TOOLBAR_DEBUG,
     });
   }, []);
 

--- a/src/lib/components/AssignedTo.tsx
+++ b/src/lib/components/AssignedTo.tsx
@@ -64,7 +64,6 @@ function hashIdentifier(identifier: string) {
 }
 
 function getAvatarColor(identifier: string | undefined): Color {
-  console.log(identifier);
   // Gray if the identifier is not set
   if (identifier === undefined) {
     return '#847a8c' as Color;

--- a/src/lib/components/DebugState.tsx
+++ b/src/lib/components/DebugState.tsx
@@ -2,6 +2,7 @@ import {useContext} from 'react';
 import {useLocation} from 'react-router-dom';
 import {useApiProxyState} from 'toolbar/context/ApiProxyContext';
 import ConfigContext from 'toolbar/context/ConfigContext';
+import {DebugTarget} from 'toolbar/types/config';
 
 export default function DebugState() {
   const proxyState = useApiProxyState();
@@ -11,7 +12,7 @@ export default function DebugState() {
   return (
     <div className="fixed bottom-0 left-0 z-debug">
       <div className="bg-gray-100 p-1 text-black">
-        {debug ? (
+        {debug?.includes(DebugTarget.STATE) ? (
           <pre>
             {JSON.stringify(
               {

--- a/src/lib/components/Navigation.tsx
+++ b/src/lib/components/Navigation.tsx
@@ -14,6 +14,7 @@ import IconSettings from 'toolbar/components/icon/IconSettings';
 import {useApiProxyInstance} from 'toolbar/context/ApiProxyContext';
 import ConfigContext from 'toolbar/context/ConfigContext';
 import useNavigationExpansion from 'toolbar/hooks/useNavigationExpansion';
+import {DebugTarget} from 'toolbar/types/config';
 
 const navClassName = cx(['flex flex-col items-center gap-1 p-1']);
 
@@ -71,7 +72,7 @@ export default function Navigation() {
         <Fragment>
           <hr className={navSeparator} />
 
-          {debug ? (
+          {debug?.includes(DebugTarget.SETTINGS) ? (
             <NavLink {...toPathOrHome('/settings')} title="Settings" className={navItemClassName({})}>
               <IconSettings size="sm" />
             </NavLink>

--- a/src/lib/components/unauth/Login.tsx
+++ b/src/lib/components/unauth/Login.tsx
@@ -1,13 +1,16 @@
 import {cx} from 'cva';
-import {useCallback, useRef, useState} from 'react';
+import {useCallback, useContext, useRef, useState} from 'react';
 import UnauthPill from 'toolbar/components/unauth/UnauthPill';
 import {useApiProxyInstance} from 'toolbar/context/ApiProxyContext';
+import ConfigContext from 'toolbar/context/ConfigContext';
+import {DebugTarget} from 'toolbar/types/config';
 
 const POPUP_MESSAGE_DELAY_MS = 3_000;
 
 const buttonClass = cx('rounded-full p-1 hover:bg-gray-500 hover:underline');
 
 export default function Login() {
+  const {debug} = useContext(ConfigContext);
   const apiProxy = useApiProxyInstance();
 
   const [isLoggingIn, setIsLoggingIn] = useState(false);
@@ -27,7 +30,8 @@ export default function Login() {
     setIsLoggingIn(true);
 
     const signal = new AbortController().signal;
-    apiProxy.exec(signal, 'request-authn', []);
+
+    apiProxy.exec(signal, 'request-authn', debug?.includes(DebugTarget.LOGIN_SUCCESS) ? [] : [3000]);
 
     // start timer, after a sec ask about popups
     if (timeoutRef.current) {
@@ -36,7 +40,7 @@ export default function Login() {
     timeoutRef.current = window.setTimeout(() => {
       setShowPopupBlockerMessage(true);
     }, POPUP_MESSAGE_DELAY_MS);
-  }, [apiProxy]);
+  }, [apiProxy, debug]);
 
   return (
     <UnauthPill>

--- a/src/lib/context/ApiProxyContext.tsx
+++ b/src/lib/context/ApiProxyContext.tsx
@@ -4,6 +4,7 @@ import type {ReactNode} from 'react';
 import ConfigContext from 'toolbar/context/ConfigContext';
 import defaultConfig from 'toolbar/context/defaultConfig';
 import {getSentryIFrameOrigin} from 'toolbar/sentryApi/urls';
+import {DebugTarget} from 'toolbar/types/config';
 import ApiProxy, {type ProxyState} from 'toolbar/utils/ApiProxy';
 
 const ApiProxyStateContext = createContext<ProxyState>('connecting');
@@ -19,7 +20,7 @@ export function ApiProxyContextProvider({children}: Props) {
 
   const log = useCallback(
     (...args: unknown[]) => {
-      if (debug) {
+      if (debug?.includes(DebugTarget.LOGGING)) {
         console.log('<ApiProxyContextProvider>', ...args);
       }
     },

--- a/src/lib/hooks/useSentryClientAndScope.ts
+++ b/src/lib/hooks/useSentryClientAndScope.ts
@@ -22,18 +22,10 @@ type WindowWithSentry = Window & {
 
 export default function useSentryClientAndScope() {
   const sentryCarrier = (window as WindowWithSentry).__SENTRY__;
-  const sentryScope = sentryCarrier && getSentryScope(sentryCarrier);
-  const sentryClient = sentryCarrier && getSentryClient(sentryCarrier);
+  const scope = sentryCarrier && getSentryScope(sentryCarrier);
+  const client = sentryCarrier && getSentryClient(sentryCarrier);
 
-  if (!sentryScope || !sentryClient) {
-    // using console log for now, will change this when moving to dev tool bar repo
-
-    console.log(
-      "Couldn't find a Sentry SDK scope or client. Make sure you're using a Sentry SDK with version 7.x or 8.x"
-    );
-  }
-
-  return {scope: sentryScope, client: sentryClient};
+  return {scope, client};
 }
 
 /**

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,12 +1,42 @@
 import mount from 'toolbar/mount';
-import type {Configuration} from 'toolbar/types/config';
+import {DebugTarget, type Configuration} from 'toolbar/types/config';
 
-export interface InitProps extends Configuration {
+export interface InitConfig extends Omit<Configuration, 'debug'> {
   mountPoint?: HTMLElement | (() => HTMLElement);
+
+  debug: undefined | string;
 }
 export type Cleanup = () => void;
 
-export function init({mountPoint, ...config}: InitProps): Cleanup {
+export function init(initConfig: InitConfig): Cleanup {
+  const {mountPoint} = initConfig;
   const root = typeof mountPoint === 'function' ? mountPoint() : mountPoint;
-  return mount(root ?? document.body, config);
+
+  return mount(root ?? document.body, hydrateConfig(initConfig));
+}
+
+function hydrateConfig(config: InitConfig): Configuration {
+  return {
+    ...config,
+    debug: hydrateDebug(config.debug),
+  };
+}
+
+function hydrateDebug(debug: InitConfig['debug']): Configuration['debug'] {
+  if (debug === undefined || debug === 'false' || debug === '') {
+    return [];
+  }
+  const parts = debug?.split(',');
+  const debugTargets = Object.values(DebugTarget);
+
+  if (parts.includes('all')) {
+    return debugTargets;
+  }
+
+  const enabled: NonNullable<Configuration['debug']> = [];
+  debugTargets.forEach(target => {
+    if (parts.includes(target)) {
+      enabled.push(target);
+    }
+  });
 }

--- a/src/lib/types/config.ts
+++ b/src/lib/types/config.ts
@@ -82,8 +82,25 @@ interface RenderConfig {
   theme?: 'system' | 'dark' | 'light';
 }
 
+export enum DebugTarget {
+  LOGGING = 'logging',
+  LOGIN_SUCCESS = 'login-success',
+  SETTINGS = 'settings',
+  STATE = 'state',
+}
 interface DebugConfig {
-  debug?: boolean;
+  /**
+   * You can set debugging to a comma-separated string containing
+   * different levels of debugging to enable.
+   *
+   * Set to "all" to enable everything.
+   *
+   * The list of different topics is:
+   * - `logging`
+   * - `login-success`
+   * - `state`
+   */
+  debug?: DebugTarget[];
 }
 
 export interface Configuration extends ConnectionConfig, FeatureFlagsConfig, OrgConfig, RenderConfig, DebugConfig {

--- a/src/lib/utils/ApiProxy.spec.ts
+++ b/src/lib/utils/ApiProxy.spec.ts
@@ -267,7 +267,6 @@ describe('ApiProxy', () => {
       sendPortConnect(proxy);
 
       const promise = proxy.exec(new AbortController().signal, 'log', ['hello world']);
-      console.log(requestPostMessageSpy.mock.calls);
       expect(requestPostMessageSpy).toHaveBeenCalledWith(
         {$id: 1, message: {$function: 'log', $args: ['hello world']}},
         []

--- a/src/lib/utils/ApiProxy.ts
+++ b/src/lib/utils/ApiProxy.ts
@@ -1,5 +1,5 @@
 import {getSentryIFrameOrigin} from 'toolbar/sentryApi/urls';
-import type {Configuration} from 'toolbar/types/config';
+import {DebugTarget, type Configuration} from 'toolbar/types/config';
 
 type Resolve = (value: unknown) => void;
 type Reject = (reason?: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -47,7 +47,7 @@ export default class ApiProxy {
   }
 
   private log(...args: unknown[]) {
-    if (this._config.debug) {
+    if (this._config.debug?.includes(DebugTarget.LOGGING)) {
       console.log('ApiProxy', ...args);
     }
   }


### PR DESCRIPTION
The typedoc is the only documentation so far, and it says:
```
   * You can set debugging to a comma-separated string containing
   * different levels of debugging to enable.
   *
   * See `enum DebugTarget` for what specific targets are available.
   * Include the target `all` to enable everything.
```

So if you have an `.env` file then you can set:
```filename=.env
# only a few things enabled
VITE_SENTRY_TOOLBAR_DEBUG=logging,state
```
or 
```filename=.env
# everthing enabled
VITE_SENTRY_TOOLBAR_DEBUG=all
```
or
```filename=.env
# no debugging
VITE_SENTRY_TOOLBAR_DEBUG=
```