### PR TITLE
feat: Simplify config by removing sentryRegion setting

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -5,7 +5,6 @@ import localStorage from 'toolbar/utils/localStorage';
 
 const baseConfig = {
   sentryOrigin: 'http://localhost:8080',
-  sentryRegion: 'us',
   sentryApiPath: '/api/0',
 
   // FeatureFlagsConfig

--- a/docs/conditional-script.md
+++ b/docs/conditional-script.md
@@ -119,7 +119,6 @@ function MyReactApp() {
 
       // ConnectionConfig
       sentryOrigin: 'https://sentry.sentry.io',
-      sentryRegion: 'us',
       sentryApiPath: '/api/0',
 
       // FeatureFlagsConfig

--- a/src/env/demo/App.tsx
+++ b/src/env/demo/App.tsx
@@ -12,7 +12,6 @@ export default function App() {
 
       // ConnectionConfig -> See .env.example for defaults
       sentryOrigin: import.meta.env.VITE_SENTRY_ORIGIN ?? 'http://localhost:8080',
-      sentryRegion: import.meta.env.VITE_SENTRY_REGION ?? undefined,
       sentryApiPath: import.meta.env.VITE_SENTRY_API_PATH ?? '/region/us/api/0',
 
       // FeatureFlagsConfig

--- a/src/lib/context/__mocks__/defaultConfig.ts
+++ b/src/lib/context/__mocks__/defaultConfig.ts
@@ -3,7 +3,6 @@ import type {Configuration} from 'toolbar/types/config';
 const defaultConfig: Configuration = {
   // ConnectionConfig
   sentryOrigin: 'https://sentry.io',
-  sentryRegion: 'us',
   sentryApiPath: '/api/0',
 
   // FeatureFlagsConfig

--- a/src/lib/context/defaultConfig.ts
+++ b/src/lib/context/defaultConfig.ts
@@ -3,7 +3,6 @@ import type {Configuration} from 'toolbar/types/config';
 const defaultConfig: Configuration = {
   // ConnectionConfig
   sentryOrigin: 'https://test.sentry.io',
-  sentryRegion: 'us',
   sentryApiPath: '/api/0',
 
   // FeatureFlagsConfig

--- a/src/lib/sentryApi/urls.spec.ts
+++ b/src/lib/sentryApi/urls.spec.ts
@@ -9,10 +9,9 @@ type TestCase = [
 ];
 const testCases: TestCase[] = [
   [
-    'SaaS config: root only, no region',
+    'SaaS config: root',
     {
       sentryOrigin: 'https://sentry.io',
-      sentryRegion: undefined,
       sentryApiPath: '/api/0/',
       organizationSlug: 'acme',
     },
@@ -23,43 +22,14 @@ const testCases: TestCase[] = [
     },
   ],
   [
-    'SaaS config: subdomain, no region',
+    'SaaS config: subdomain',
     {
       sentryOrigin: 'https://acme.sentry.io',
-      sentryRegion: undefined,
       sentryApiPath: '/api/0/',
       organizationSlug: 'acme',
     },
     {
       getSentryApiBaseUrl: 'https://acme.sentry.io/api/0/',
-      getSentryWebOrigin: 'https://acme.sentry.io',
-      getSentryIFrameOrigin: 'https://acme.sentry.io',
-    },
-  ],
-  [
-    'SaaS config: root, insert region',
-    {
-      sentryOrigin: 'https://sentry.io',
-      sentryRegion: 'us',
-      sentryApiPath: '/api/0/',
-      organizationSlug: 'acme',
-    },
-    {
-      getSentryApiBaseUrl: 'https://acme.sentry.io/region/us/api/0/',
-      getSentryWebOrigin: 'https://acme.sentry.io',
-      getSentryIFrameOrigin: 'https://acme.sentry.io',
-    },
-  ],
-  [
-    'SaaS config: subdomain, replace with region',
-    {
-      sentryOrigin: 'https://acme.sentry.io',
-      sentryRegion: 'us',
-      sentryApiPath: '/api/0/',
-      organizationSlug: 'acme',
-    },
-    {
-      getSentryApiBaseUrl: 'https://acme.sentry.io/region/us/api/0/',
       getSentryWebOrigin: 'https://acme.sentry.io',
       getSentryIFrameOrigin: 'https://acme.sentry.io',
     },
@@ -68,21 +38,6 @@ const testCases: TestCase[] = [
     'sentry devserver config',
     {
       sentryOrigin: 'https://dev.getsentry.net:8000',
-      sentryRegion: undefined,
-      sentryApiPath: '/api/0',
-      organizationSlug: 'acme',
-    },
-    {
-      getSentryApiBaseUrl: 'https://dev.getsentry.net:8000/api/0',
-      getSentryWebOrigin: 'https://dev.getsentry.net:8000',
-      getSentryIFrameOrigin: 'https://dev.getsentry.net:8000',
-    },
-  ],
-  [
-    'sentry devserver config with region configured',
-    {
-      sentryOrigin: 'https://dev.getsentry.net:8000',
-      sentryRegion: 'us',
       sentryApiPath: '/api/0',
       organizationSlug: 'acme',
     },
@@ -96,7 +51,6 @@ const testCases: TestCase[] = [
     'yarn dev:standalone config',
     {
       sentryOrigin: 'http://localhost:8080',
-      sentryRegion: undefined,
       sentryApiPath: '/api/0',
       organizationSlug: 'acme',
     },

--- a/src/lib/types/config.ts
+++ b/src/lib/types/config.ts
@@ -13,15 +13,6 @@ interface ConnectionConfig {
   sentryOrigin: string;
 
   /**
-   * The region of the sentry organization when hosted on Sentry Cloud.`
-   *
-   * Valid values: `"us"` or `"de"`
-   *
-   * Only applies if you're using Sentry Cloud on `sentry.io` as your sentry origin.
-   */
-  sentryRegion: string | undefined;
-
-  /**
    * The path prefix for the api endpoints.
    *
    * Example: `/api/0`


### PR DESCRIPTION
We can instead pass this from the server side to config it automatically.