### PR TITLE
fix: Improve transaction name to search to support uuid, and better `/` handling

### DIFF
--- a/src/lib/hooks/useCurrentSentryTransactionName.ts
+++ b/src/lib/hooks/useCurrentSentryTransactionName.ts
@@ -17,5 +17,6 @@ export default function useCurrentSentryTransactionName() {
     return () => {};
   }, [client]);
 
+  console.log({transactionName, searchTerm: transactionToSearchTerm(transactionName)});
   return transactionToSearchTerm(transactionName);
 }

--- a/src/lib/hooks/useCurrentSentryTransactionName.ts
+++ b/src/lib/hooks/useCurrentSentryTransactionName.ts
@@ -17,6 +17,5 @@ export default function useCurrentSentryTransactionName() {
     return () => {};
   }, [client]);
 
-  console.log({transactionName, searchTerm: transactionToSearchTerm(transactionName)});
   return transactionToSearchTerm(transactionName);
 }

--- a/src/lib/utils/transactionToSearchTerm.spec.ts
+++ b/src/lib/utils/transactionToSearchTerm.spec.ts
@@ -1,12 +1,12 @@
-import toSearchTerm from 'toolbar/utils/transactionToSearchTerm';
+import transactionToSearchTerm from 'toolbar/utils/transactionToSearchTerm';
 
-describe('getSearchTerm', () => {
+describe('transactionToSearchTerm', () => {
   it.each([
     {
       transactionName: '//alerts/rules/details/:ruleId/',
       searchTerm: '/alerts/rules/details/*/',
     },
-    {transactionName: '/pokemon/[pokemonName]', searchTerm: '/pokemon/*/'},
+    {transactionName: '/pokemon/[pokemonName]', searchTerm: '/pokemon/*'},
     {transactionName: '/replays/<id>/details/', searchTerm: '/replays/*/details/'},
     {
       transactionName: '/param/{id}/param2/key:value/',
@@ -15,11 +15,11 @@ describe('getSearchTerm', () => {
     {transactionName: '/issues/4489703641/', searchTerm: '/issues/*/'},
     {
       transactionName: 'v1.3/tutorial/event/123',
-      searchTerm: '/v1.3/tutorial/event/*/',
+      searchTerm: 'v1.3/tutorial/event/*',
     },
     {
       transactionName: '/all/:id1/:id2/param',
-      searchTerm: '/all/*/*/param/',
+      searchTerm: '/all/*/*/param',
     },
     {
       transactionName: '//settings/account/emails/',
@@ -37,7 +37,71 @@ describe('getSearchTerm', () => {
       transactionName: '/',
       searchTerm: '/',
     },
-  ])('should get the correct search term from the transaction name', ({transactionName, searchTerm}) => {
-    expect(toSearchTerm(transactionName)).toStrictEqual(searchTerm);
+    {
+      transactionName: '/hello/:param/world/[param]/foo/{param}/bar/<param>/biz/',
+      searchTerm: '/hello/*/world/*/foo/*/bar/*/biz/',
+    },
+    {
+      transactionName: '/hello/:param/[param]/{param}/<param>/world/',
+      searchTerm: '/hello/*/*/*/*/world/',
+    },
+    {
+      transactionName: '/hello/:param/[param]/{param}/<param>/world',
+      searchTerm: '/hello/*/*/*/*/world',
+    },
+    {
+      transactionName: '/hello/:param/[param]/{param}/<param>/',
+      searchTerm: '/hello/*/*/*/*/',
+    },
+    {
+      transactionName: '/hello/:param/[param]/{param}/<param>',
+      searchTerm: '/hello/*/*/*/*',
+    },
+    {
+      transactionName: '/:param/[param]/{param}/<param>/world/',
+      searchTerm: '/*/*/*/*/world/',
+    },
+    {
+      transactionName: ':param/[param]/{param}/<param>/world/',
+      searchTerm: '*/*/*/*/world/',
+    },
+    {
+      transactionName: ':param/[param]/{param}/<param>/world',
+      searchTerm: '*/*/*/*/world',
+    },
+    {
+      transactionName: ':param/[param]/{param}/<param>/',
+      searchTerm: '*/*/*/*/',
+    },
+    {
+      transactionName: ':param/[param]/{param}/<param>',
+      searchTerm: '*/*/*/*',
+    },
+    {
+      transactionName: ':param/:param/:param/:param',
+      searchTerm: '*/*/*/*',
+    },
+    {
+      transactionName: '[param]/[param]/[param]/[param]',
+      searchTerm: '*/*/*/*',
+    },
+    {
+      transactionName: '{param}/{param}/{param}/{param}',
+      searchTerm: '*/*/*/*',
+    },
+    {
+      transactionName: '<param>/<param>/<param>/<param>',
+      searchTerm: '*/*/*/*',
+    },
+    {
+      transactionName: '/some/uuid/d3aa88e2-c754-41e0-8ba6-4198a34aa0a2/',
+      searchTerm: '/some/uuid/*/',
+    },
+    {
+      transactionName: '/some/uuid/d3aa88e2c75441e08ba64198a34aa0a2/',
+      searchTerm: '/some/uuid/*/',
+    },
+  ])('should change $transactionName', ({transactionName, searchTerm}) => {
+    expect(transactionToSearchTerm(transactionName)).toStrictEqual(searchTerm);
   });
 });

--- a/src/lib/utils/transactionToSearchTerm.ts
+++ b/src/lib/utils/transactionToSearchTerm.ts
@@ -1,20 +1,27 @@
-// ([:]([^/]*)) matches :param used by React, Vue, Angular, Express, Ruby on Rails, Phoenix, Solid
-// ([[]([^/]*)[\]]) matches [param] used by Next.js, Nuxt.js, Svelte
-// ([{]([^/]*)[}]) matches {param} used by ASP.NET Core, Laravel, Symfony
-// ([<]([^/]*)[>]) matches <param> used by Flask, Django
-const PARAMETERIZED_REGEX = /([/])(([:]([^/]*))|([[]([^/]*)[\]])|([{]([^/]*)[}])|([<]([^/]*)[>]))/g;
+// (:[^/:]+) matches `:param` used by React, Vue, Angular, Express, Ruby on Rails, Phoenix, Solid
+// (\[[^/\]]+\]) matches `[param]` used by Next.js, Nuxt.js, Svelte
+// ({[^/}]+}) matches `{param}` used by ASP.NET Core, Laravel, Symfony
+// (<[^>/]+>) matches `<param>` used by Flask, Django
+const PARAMETERIZED_REGEX = /^((:[^/:]+)|(\[[^/\]]+\])|({[^/}]+})|(<[^>/]+>))$/;
 
 // Transaction name could contain the resolved URL instead of the route pattern
-// (ie: actual `id` instead of `:id`) so we match any param that starts with a
-// number eg. /12353
-const NON_PARAMETERIZED_REGEX = /([/])([0-9]+)/g;
+// (ie: actual `id` instead of `:id`) so we match any param that is a number.
+const NON_PARAMETERIZED_REGEX = /^[0-9]+$/;
+
+// Match an RFC4122 UUID, any version from 1-5 including the NIL UUID.
+// With or without groups separated by `-`
+// See: https://stackoverflow.com/a/13653180
+// See: https://www.rfc-editor.org/rfc/rfc4122#section-4.1.7
+const UUID_REGEX = /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-5][0-9a-f]{3}-?[089ab][0-9a-f]{3}-?[0-9a-f]{12}$/i;
 
 export default function transactionToSearchTerm(transaction: string) {
   // Find dynamic parts of transaction name to change into search term
-  const modifiedTransaction = transaction
-    .replaceAll(PARAMETERIZED_REGEX, '/*')
-    .replaceAll(NON_PARAMETERIZED_REGEX, '/*');
+  const parts = transaction
+    .split('/')
+    .map(segment =>
+      segment.replace(PARAMETERIZED_REGEX, '*').replace(NON_PARAMETERIZED_REGEX, '*').replace(UUID_REGEX, '*')
+    );
 
   // Join the array back into a string with '/'
-  return `/${modifiedTransaction}/`.replaceAll(/\/+/g, '/');
+  return parts.join('/').replace(/\/{2,}/, '/');
 }


### PR DESCRIPTION
I say 'better' `/` handling because we're:
- Not adding leading & trailing slashes anymore
- Still replacing multiple slashes, (ie: `//`) with `/` anywhere they appear.

Before we were adding trailing `/` which wasn't working for my test site which does not require a trailing `/` in the url, therefore searches for `/cart/` were not matching `/cart` in sentry.