### PR TITLE
ref: Refactor fetching into ProjectIcon and improve ExternalLink css overriding

### DIFF
--- a/src/lib/components/base/ExternalLink.tsx
+++ b/src/lib/components/base/ExternalLink.tsx
@@ -16,7 +16,7 @@ export default function ExternalLink({children, className, to, onClick}: Props) 
   const url = qs.stringifyUrl(to);
 
   return (
-    <a href={url} onClick={onClick} rel="noreferrer noopener" target="_blank" className={className ?? linkClass}>
+    <a href={url} onClick={onClick} rel="noreferrer noopener" target="_blank" className={cx(linkClass, className)}>
       {children}
     </a>
   );

--- a/src/lib/components/panels/feedback/FeedbackListItem.tsx
+++ b/src/lib/components/panels/feedback/FeedbackListItem.tsx
@@ -6,6 +6,7 @@ import IconChat from 'toolbar/components/icon/IconChat';
 import IconFatal from 'toolbar/components/icon/IconFatal';
 import IconImage from 'toolbar/components/icon/IconImage';
 import IconPlay from 'toolbar/components/icon/IconPlay';
+import ProjectIcon from 'toolbar/components/project/ProjectIcon';
 import SentryAppLink from 'toolbar/components/SentryAppLink';
 import ConfigContext from 'toolbar/context/ConfigContext';
 import useReplayCount from 'toolbar/hooks/useReplayCount';
@@ -77,7 +78,14 @@ function FeedbackMessage({message}: {message: string | null | undefined}) {
 }
 
 function FeedbackProject({item}: {item: FeedbackIssueListItem}) {
-  return <span className="truncate text-xs">{item.shortId}</span>;
+  const {organizationSlug, projectIdOrSlug} = useContext(ConfigContext);
+
+  return (
+    <div className="flex flex-row items-center gap-0.5">
+      <ProjectIcon size="xs" organizationSlug={organizationSlug} projectIdOrSlug={projectIdOrSlug} />
+      <span className="truncate text-xs">{item.shortId}</span>;
+    </div>
+  );
 }
 
 function useReplayCountForFeedbacks(organization: string | number) {

--- a/src/lib/components/panels/feedback/FeedbackPanel.tsx
+++ b/src/lib/components/panels/feedback/FeedbackPanel.tsx
@@ -1,23 +1,19 @@
 import {useContext} from 'react';
-import PlatformIcon from 'toolbar/components/icon/PlatformIcon';
 import InfiniteListItems from 'toolbar/components/InfiniteListItems';
 import InfiniteListState from 'toolbar/components/InfiniteListState';
 import FeedbackListItem from 'toolbar/components/panels/feedback/FeedbackListItem';
 import useInfiniteFeedbackList from 'toolbar/components/panels/feedback/useInfiniteFeedbackList';
 import Placeholder from 'toolbar/components/Placeholder';
+import ProjectIcon from 'toolbar/components/project/ProjectIcon';
 import SentryAppLink from 'toolbar/components/SentryAppLink';
 import ConfigContext from 'toolbar/context/ConfigContext';
 import useFetchSentryData from 'toolbar/hooks/fetch/useFetchSentryData';
 import useCurrentSentryTransactionName from 'toolbar/hooks/useCurrentSentryTransactionName';
-import {useMembersQuery, useTeamsQuery, useProjectQuery} from 'toolbar/sentryApi/queryKeys';
+import {useMembersQuery, useTeamsQuery} from 'toolbar/sentryApi/queryKeys';
 import type {FeedbackIssueListItem} from 'toolbar/sentryApi/types/group';
 
 export default function FeedbackPanel() {
   const {organizationSlug, projectIdOrSlug} = useContext(ConfigContext);
-
-  const {data: project, isSuccess: projectIsSuccess} = useFetchSentryData({
-    ...useProjectQuery(String(organizationSlug), String(projectIdOrSlug)),
-  });
 
   const transactionName = useCurrentSentryTransactionName();
   const queryResult = useInfiniteFeedbackList({
@@ -39,7 +35,7 @@ export default function FeedbackPanel() {
         <SentryAppLink
           className="flex flex-row items-center gap-1 font-medium"
           to={{url: `/issues/`, query: {project: organizationSlug}}}>
-          <PlatformIcon isLoading={!projectIsSuccess} platform={project?.json.platform ?? 'default'} size="sm" />
+          <ProjectIcon size="sm" organizationSlug={organizationSlug} projectIdOrSlug={projectIdOrSlug} />
           Feedback
         </SentryAppLink>
       </h1>

--- a/src/lib/components/panels/issues/IssueListItem.tsx
+++ b/src/lib/components/panels/issues/IssueListItem.tsx
@@ -2,6 +2,7 @@ import {cx} from 'cva';
 import {useContext} from 'react';
 import AssignedTo from 'toolbar/components/AssignedTo';
 import RelativeDateTime from 'toolbar/components/datetime/RelativeDateTime';
+import ProjectIcon from 'toolbar/components/project/ProjectIcon';
 import SentryAppLink from 'toolbar/components/SentryAppLink';
 import ConfigContext from 'toolbar/context/ConfigContext';
 import type {Group} from 'toolbar/sentryApi/types/group';
@@ -30,7 +31,7 @@ export default function IssueListItem({
         <IssueMessage message={item.metadata.value} />
         <div className="flex justify-between">
           <IssueProject item={item} />
-          <AssignedTo assignedTo={item.assignedTo} teams={teams} members={members} />
+          {item.assignedTo ? <AssignedTo assignedTo={item.assignedTo} teams={teams} members={members} /> : null}
         </div>
       </div>
     </div>
@@ -64,5 +65,12 @@ function IssueMessage({message}: {message: string | null | undefined}) {
 }
 
 function IssueProject({item}: {item: Group}) {
-  return <span className="truncate text-xs">{item.shortId}</span>;
+  const {organizationSlug, projectIdOrSlug} = useContext(ConfigContext);
+
+  return (
+    <div className="flex flex-row items-center gap-0.5">
+      <ProjectIcon size="xs" organizationSlug={organizationSlug} projectIdOrSlug={projectIdOrSlug} />
+      <span className="truncate text-xs">{item.shortId}</span>
+    </div>
+  );
 }

--- a/src/lib/components/panels/issues/IssuesPanel.tsx
+++ b/src/lib/components/panels/issues/IssuesPanel.tsx
@@ -1,23 +1,19 @@
 import {useContext} from 'react';
-import PlatformIcon from 'toolbar/components/icon/PlatformIcon';
 import InfiniteListItems from 'toolbar/components/InfiniteListItems';
 import InfiniteListState from 'toolbar/components/InfiniteListState';
 import IssueListItem from 'toolbar/components/panels/issues/IssueListItem';
 import useInfiniteIssuesList from 'toolbar/components/panels/issues/useInfiniteIssuesList';
 import Placeholder from 'toolbar/components/Placeholder';
+import ProjectIcon from 'toolbar/components/project/ProjectIcon';
 import SentryAppLink from 'toolbar/components/SentryAppLink';
 import ConfigContext from 'toolbar/context/ConfigContext';
 import useFetchSentryData from 'toolbar/hooks/fetch/useFetchSentryData';
 import useCurrentSentryTransactionName from 'toolbar/hooks/useCurrentSentryTransactionName';
-import {useMembersQuery, useTeamsQuery, useProjectQuery} from 'toolbar/sentryApi/queryKeys';
+import {useMembersQuery, useTeamsQuery} from 'toolbar/sentryApi/queryKeys';
 import type {Group} from 'toolbar/sentryApi/types/group';
 
 export default function IssuesPanel() {
   const {organizationSlug, projectIdOrSlug} = useContext(ConfigContext);
-
-  const {data: project, isSuccess: projectIsSuccess} = useFetchSentryData({
-    ...useProjectQuery(String(organizationSlug), String(projectIdOrSlug)),
-  });
 
   const transactionName = useCurrentSentryTransactionName();
   const queryResult = useInfiniteIssuesList({
@@ -39,7 +35,7 @@ export default function IssuesPanel() {
         <SentryAppLink
           className="flex flex-row items-center gap-1 font-medium"
           to={{url: `/issues/`, query: {project: organizationSlug}}}>
-          <PlatformIcon isLoading={!projectIsSuccess} platform={project?.json.platform ?? 'default'} size="sm" />
+          <ProjectIcon size="sm" organizationSlug={organizationSlug} projectIdOrSlug={projectIdOrSlug} />
           Issues
         </SentryAppLink>
       </h1>

--- a/src/lib/components/project/ProjectIcon.tsx
+++ b/src/lib/components/project/ProjectIcon.tsx
@@ -1,0 +1,17 @@
+import PlatformIcon from 'toolbar/components/icon/PlatformIcon';
+import useFetchSentryData from 'toolbar/hooks/fetch/useFetchSentryData';
+import {useProjectQuery} from 'toolbar/sentryApi/queryKeys';
+
+interface Props {
+  size?: React.ComponentProps<typeof PlatformIcon>['size'];
+  organizationSlug: string;
+  projectIdOrSlug: string | number;
+}
+
+export default function ProjectIcon({size, organizationSlug, projectIdOrSlug}: Props) {
+  const {data, isSuccess} = useFetchSentryData({
+    ...useProjectQuery(String(organizationSlug), String(projectIdOrSlug)),
+  });
+
+  return <PlatformIcon size={size} isLoading={!isSuccess} platform={data?.json.platform ?? 'default'} />;
+}

--- a/src/lib/types/config.ts
+++ b/src/lib/types/config.ts
@@ -36,7 +36,7 @@ interface OrgConfig {
   /**
    * The organization that users should login to
    */
-  organizationSlug: string | number;
+  organizationSlug: string;
 
   /**
    * The project for which this website is associated


### PR DESCRIPTION
Panel title looks like a link now & we have `<ProjectIcon>` next to each issue-id

<img width="328" alt="SCR-20241126-mkhp" src="https://github.com/user-attachments/assets/7225ed50-4136-4933-8cbf-de0369fd1b02">
