### PR TITLE
feat: RelativeDateTime auto-updates the relative rendered string

### DIFF
--- a/src/lib/components/datetime/RelativeDateTime.tsx
+++ b/src/lib/components/datetime/RelativeDateTime.tsx
@@ -1,10 +1,21 @@
 import type {FormatDistanceToken} from 'date-fns';
 import {formatDistanceToNowStrict} from 'date-fns/formatDistanceToNowStrict';
+import {useCallback, useEffect, useRef} from 'react';
 
-export default function RelativeDateTime({date, suffix}: {date: Date; suffix: string}) {
-  return (
-    <time dateTime={date.toISOString()}>
-      {formatDistanceToNowStrict(date, {
+interface Props {
+  date: Date;
+  suffix: string;
+  updateInterval?: 'second' | 'minute' | 'hour';
+}
+
+export default function RelativeDateTime({date, suffix, updateInterval}: Props) {
+  const elem = useRef<HTMLTimeElement>(null);
+
+  const timeout = useRef<number | null>(null);
+
+  const getDistance = useCallback(
+    () =>
+      formatDistanceToNowStrict(date, {
         roundingMethod: 'floor',
         locale: {
           formatDistance: (token: FormatDistanceToken, count: number) => {
@@ -20,7 +31,56 @@ export default function RelativeDateTime({date, suffix}: {date: Date; suffix: st
             return formatMap[token] || `${count}d`;
           },
         },
-      })}
-    </time>
+      }),
+    [date, suffix]
   );
+
+  useEffect(() => {
+    const updateDuration = intervalToTimeout(updateInterval ?? getRecommendedInterval(date));
+    const createTimeout = () =>
+      window.setTimeout(() => {
+        if (elem.current) {
+          elem.current.innerText = getDistance();
+        }
+        timeout.current = createTimeout();
+      }, updateDuration);
+
+    timeout.current = createTimeout();
+
+    return () => {
+      if (timeout.current) {
+        window.clearTimeout(timeout.current);
+        timeout.current = null;
+      }
+    };
+  }, [date, getDistance, updateInterval]);
+
+  return <time ref={elem} dateTime={date.toISOString()} dangerouslySetInnerHTML={{__html: getDistance()}}></time>;
+}
+
+enum DurationInMS {
+  SECOND = 1_000,
+  MINUTE = 1_000 * 60,
+  HOUR = 1_000 * 60 * 60,
+}
+
+function getRecommendedInterval(date: Date): NonNullable<Props['updateInterval']> {
+  const difference = Math.abs(Date.now() - date.getTime());
+  if (difference < DurationInMS.MINUTE) {
+    return 'second';
+  } else if (difference < DurationInMS.HOUR) {
+    return 'minute';
+  } else {
+    return 'hour';
+  }
+}
+
+function intervalToTimeout(interval: NonNullable<Props['updateInterval']>) {
+  if (interval === 'second') {
+    return DurationInMS.SECOND;
+  } else if (interval === 'minute') {
+    return DurationInMS.MINUTE;
+  } else if (interval === 'hour') {
+    return DurationInMS.HOUR;
+  }
 }

--- a/src/lib/components/datetime/RelativeDateTime.tsx
+++ b/src/lib/components/datetime/RelativeDateTime.tsx
@@ -36,14 +36,14 @@ export default function RelativeDateTime({date, suffix, updateInterval}: Props) 
   );
 
   useEffect(() => {
-    const updateDuration = intervalToTimeout(updateInterval ?? getRecommendedInterval(date));
+    const timeoutDuration = intervalToTimeout(updateInterval ?? getRecommendedInterval(date));
     const createTimeout = () =>
       window.setTimeout(() => {
         if (elem.current) {
           elem.current.innerText = getDistance();
         }
         timeout.current = createTimeout();
-      }, updateDuration);
+      }, timeoutDuration);
 
     timeout.current = createTimeout();
 


### PR DESCRIPTION
Just have it auto-update the string `24min ago` to be `25min ago` if you've looking at the page for a while.

The update interval can be set manually to either `second`, `minute` or `hour` but if you don't set it then we'll see how old is the date, and set an interval that's appropriate. If the timestamp starts being really recent, then we'll update it every second, but if you keep the page open for hours and hour then we'll get a new value from getRecommendedInterval()` and slow down the updates because it won't be changing as often anyway.

I'm using `dangerouslySetInnerHTML` here to keep react away from the changing values. If i were mutating the children directly and react wanted to re-render it could be surprised that the value is not what it expected. 