### PR TITLE
ref: Refactor locale definition so its statically setup at app startup

### DIFF
--- a/src/lib/components/datetime/RelativeDateTime.tsx
+++ b/src/lib/components/datetime/RelativeDateTime.tsx
@@ -1,14 +1,14 @@
-import type {FormatDistanceToken} from 'date-fns';
+import type {Locale} from 'date-fns';
 import {formatDistanceToNowStrict} from 'date-fns/formatDistanceToNowStrict';
 import {useCallback, useEffect, useRef} from 'react';
 
 interface Props {
   date: Date;
-  suffix: string;
+  locale?: Locale;
   updateInterval?: 'second' | 'minute' | 'hour';
 }
 
-export default function RelativeDateTime({date, suffix, updateInterval}: Props) {
+export default function RelativeDateTime({date, locale, updateInterval}: Props) {
   const elem = useRef<HTMLTimeElement>(null);
 
   const timeout = useRef<number | null>(null);
@@ -17,22 +17,10 @@ export default function RelativeDateTime({date, suffix, updateInterval}: Props) 
     () =>
       formatDistanceToNowStrict(date, {
         roundingMethod: 'floor',
-        locale: {
-          formatDistance: (token: FormatDistanceToken, count: number) => {
-            const formatMap: Partial<Record<FormatDistanceToken, string>> = {
-              xSeconds: `${count}s ${suffix}`,
-              xMinutes: `${count}min ${suffix}`,
-              xHours: `${count}hr ${suffix}`,
-              xDays: `${count}d ${suffix}`,
-              xWeeks: `${count}w ${suffix}`,
-              xMonths: `${count}mo ${suffix}`,
-              xYears: `${count}y ${suffix}`,
-            };
-            return formatMap[token] || `${count}d`;
-          },
-        },
+        addSuffix: true,
+        locale,
       }),
-    [date, suffix]
+    [date, locale]
   );
 
   useEffect(() => {

--- a/src/lib/components/panels/feedback/FeedbackListItem.tsx
+++ b/src/lib/components/panels/feedback/FeedbackListItem.tsx
@@ -68,7 +68,7 @@ function FeedbackType({item}: {item: FeedbackIssueListItem}) {
 function FeedbackDates({firstSeen}: {firstSeen: string}) {
   return (
     <span className="flex items-center gap-0.5 whitespace-nowrap text-xs text-gray-300">
-      <RelativeDateTime date={new Date(firstSeen)} suffix="ago" />
+      <RelativeDateTime date={new Date(firstSeen)} />
     </span>
   );
 }

--- a/src/lib/components/panels/issues/IssueListItem.tsx
+++ b/src/lib/components/panels/issues/IssueListItem.tsx
@@ -8,6 +8,7 @@ import ConfigContext from 'toolbar/context/ConfigContext';
 import type {Group} from 'toolbar/sentryApi/types/group';
 import type Member from 'toolbar/sentryApi/types/Member';
 import type {OrganizationTeam} from 'toolbar/sentryApi/types/Organization';
+import {localeTimeAgeAbbr} from 'toolbar/utils/locale';
 
 export default function IssueListItem({
   item,
@@ -53,9 +54,9 @@ function IssueType({item}: {item: Group}) {
 function IssueSeenDates({firstSeen, lastSeen}: {firstSeen: string; lastSeen: string}) {
   return (
     <span className="flex items-center gap-0.5 whitespace-nowrap text-xs text-gray-300">
-      <RelativeDateTime date={new Date(lastSeen)} suffix="ago" />
+      <RelativeDateTime date={new Date(lastSeen)} />
       <span className="font-bold">·</span>
-      <RelativeDateTime date={new Date(firstSeen)} suffix="old" />
+      <RelativeDateTime date={new Date(firstSeen)} locale={localeTimeAgeAbbr} />
     </span>
   );
 }

--- a/src/lib/mount.tsx
+++ b/src/lib/mount.tsx
@@ -1,12 +1,16 @@
+import {setDefaultOptions} from 'date-fns';
 import {StrictMode} from 'react';
 import {createRoot} from 'react-dom/client';
 import AppRouter from 'toolbar/components/AppRouter';
 import Providers from 'toolbar/context/Providers';
 import styles from 'toolbar/index.css?inline'; // returned as a string
 import type {Configuration} from 'toolbar/types/config';
+import {localeTimeRelativeAbbr} from 'toolbar/utils/locale';
 
 export default function mount(rootNode: HTMLElement, config: Configuration) {
   const {host, reactMount, portalMount} = buildDom(config);
+
+  setDefaultOptions({locale: localeTimeRelativeAbbr});
 
   const cleanup = setColorScheme(reactMount, config.theme ?? 'system');
 

--- a/src/lib/utils/locale.ts
+++ b/src/lib/utils/locale.ts
@@ -1,0 +1,47 @@
+import type {FormatDistanceFn, FormatDistanceFnOptions, FormatDistanceToken} from 'date-fns';
+import {enUS} from 'date-fns/locale/en-US';
+
+const distanceUnitAbbr: Record<FormatDistanceToken, string> = {
+  lessThanXSeconds: '{{count}}s',
+  xSeconds: '{{count}}s',
+  halfAMinute: '30s',
+  lessThanXMinutes: '{{count}}m',
+  xMinutes: '{{count}}m',
+  aboutXHours: '{{count}}h',
+  xHours: '{{count}}h',
+  xDays: '{{count}}d',
+  aboutXWeeks: '{{count}}w',
+  xWeeks: '{{count}}w',
+  aboutXMonths: '{{count}}m',
+  xMonths: '{{count}}m',
+  aboutXYears: '{{count}}y',
+  xYears: '{{count}}y',
+  overXYears: '{{count}}y',
+  almostXYears: '{{count}}y',
+};
+
+function makeFormatDistance(
+  distanceUnitMap: Record<FormatDistanceToken, string>,
+  futureTemplate: string,
+  pastTemplate: string
+): FormatDistanceFn {
+  return (token: FormatDistanceToken, count: number, options: FormatDistanceFnOptions = {}): string => {
+    const result = distanceUnitMap[token].replace('{{count}}', String(count));
+    if (options.addSuffix) {
+      return options.comparison === 1
+        ? futureTemplate.replace('{{distance}}', result)
+        : pastTemplate.replace('{{distance}}', result);
+    }
+    return result;
+  };
+}
+
+export const localeTimeRelativeAbbr = {
+  ...enUS,
+  formatDistance: makeFormatDistance(distanceUnitAbbr, 'in {{distance}}', '{{distance}} ago'),
+};
+
+export const localeTimeAgeAbbr = {
+  ...enUS,
+  formatDistance: makeFormatDistance(distanceUnitAbbr, 'in {{distance}}', '{{distance}} old'),
+};


### PR DESCRIPTION
This moves the `formatDistance` definition out into it's own file so we can define it once and import it whenever; instead of each component creating it's own instance of the function.

I also iterated on the `suffix={string}` param and converted that into a `locale` param. With `suffix and/or `prefix` we endup with hard-to-translate strings in the end, which is a bad pattern to setup. Instead we can pass in a `Locale` object that can have custom methods to format the strings. So far i've defined two locale's with different `formatDistance` implementations: one implementation adds the `"... ago"` suffix, and the other adds the `"... old"` suffix. Pass in the desired locale as-needed.