### PR TITLE
feat: Create a Tooltip component and use it with ProjectIcon

### DIFF
--- a/src/lib/components/base/tooltip/Tooltip.stories.tsx
+++ b/src/lib/components/base/tooltip/Tooltip.stories.tsx
@@ -1,0 +1,49 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {Tooltip, TooltipTrigger, TooltipContent} from 'toolbar/components/base/tooltip/Tooltip';
+
+const meta: Meta<typeof Tooltip> = {
+  title: 'components/base/tooltip/Tooltip',
+  component: Tooltip,
+  argTypes: {},
+};
+
+export default meta;
+type Story = StoryObj<typeof Tooltip>;
+
+export const Default: Story = {
+  args: {},
+  render: () => {
+    return (
+      <Tooltip>
+        <TooltipTrigger>today</TooltipTrigger>
+        <TooltipContent>{new Date().toISOString()}</TooltipContent>
+      </Tooltip>
+    );
+  },
+};
+
+export const PointingDown: Story = {
+  args: {},
+  render: () => {
+    return (
+      <Tooltip open>
+        <TooltipTrigger>today</TooltipTrigger>
+        <TooltipContent>{new Date().toISOString()}</TooltipContent>
+      </Tooltip>
+    );
+  },
+};
+
+export const PointingUp: Story = {
+  args: {},
+  render: () => {
+    return (
+      <div className="mt-24">
+        <Tooltip open>
+          <TooltipTrigger>today</TooltipTrigger>
+          <TooltipContent>{new Date().toISOString()}</TooltipContent>
+        </Tooltip>
+      </div>
+    );
+  },
+};

--- a/src/lib/components/base/tooltip/Tooltip.tsx
+++ b/src/lib/components/base/tooltip/Tooltip.tsx
@@ -1,0 +1,108 @@
+import {useMergeRefs, FloatingPortal, FloatingArrow} from '@floating-ui/react';
+import type {Placement} from '@floating-ui/react';
+import {cx} from 'cva';
+import type {HTMLProps, ReactNode} from 'react';
+import {cloneElement, createContext, forwardRef, isValidElement, useContext} from 'react';
+import useTooltip from 'toolbar/components/base/tooltip/useTooltip';
+import PortalTargetContext from 'toolbar/context/PortalTargetContext';
+
+interface TooltipOptions {
+  initialOpen?: boolean;
+  placement?: Placement;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+type ContextType = ReturnType<typeof useTooltip> | null;
+
+const TooltipContext = createContext<ContextType>(null);
+
+function useTooltipContext() {
+  const context = useContext(TooltipContext);
+
+  if (context == null) {
+    throw new Error('Tooltip components must be wrapped in <Tooltip />');
+  }
+
+  return context;
+}
+
+export function Tooltip({children, ...options}: {children: ReactNode} & TooltipOptions) {
+  // This can accept any props as options, e.g. `placement`,
+  // or other positioning options.
+  const tooltip = useTooltip(options);
+  return <TooltipContext.Provider value={tooltip}>{children}</TooltipContext.Provider>;
+}
+
+export const TooltipTrigger = forwardRef<HTMLElement, HTMLProps<HTMLElement> & {asChild?: boolean}>(
+  function TooltipTrigger(
+    {children, asChild = false, ...props}: HTMLProps<HTMLElement> & {asChild?: boolean},
+    propRef
+  ) {
+    const context = useTooltipContext();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const childrenRef = (children as any).ref;
+    const ref = useMergeRefs([context.refs.setReference, propRef, childrenRef]);
+
+    // `asChild` allows the user to pass any element as the anchor
+    if (asChild && isValidElement(children)) {
+      return cloneElement(
+        children,
+        context.getReferenceProps({
+          ref,
+          ...props,
+          ...children.props,
+          'data-state': context.open ? 'open' : 'closed',
+        })
+      );
+    }
+
+    return (
+      <button
+        ref={ref}
+        // The user can style the trigger based on the state
+        data-state={context.open ? 'open' : 'closed'}
+        {...context.getReferenceProps(props)}>
+        {children}
+      </button>
+    );
+  }
+);
+
+export const TooltipContent = forwardRef<HTMLDivElement, HTMLProps<HTMLDivElement>>(function TooltipContent(
+  {children, className, style, ...props}: HTMLProps<HTMLDivElement>,
+  propRef
+) {
+  const portalTarget = useContext(PortalTargetContext);
+  const context = useTooltipContext();
+
+  const ref = useMergeRefs([context.refs.setFloating, propRef]);
+  if (!context.open) {
+    return null;
+  }
+
+  return (
+    <FloatingPortal root={portalTarget}>
+      <div
+        ref={ref}
+        style={{
+          ...context.floatingStyles,
+          ...style,
+        }}
+        className={cx(
+          'max-w-60 rounded-md text-xs text-gray-400 bg-surface-400 px-1.5 py-1 shadow-sm shadow-shadow-heavy border border-translucentGray-200 z-tooltip',
+          className
+        )}
+        {...context.getFloatingProps(props)}>
+        <FloatingArrow
+          ref={context.arrowRef}
+          context={context.context}
+          stroke="var(--translucent-gray-200)"
+          strokeWidth={1}
+          fill="var(--surface-400)"
+        />
+        {children}
+      </div>
+    </FloatingPortal>
+  );
+});

--- a/src/lib/components/base/tooltip/useTooltip.ts
+++ b/src/lib/components/base/tooltip/useTooltip.ts
@@ -1,0 +1,79 @@
+import {
+  useFloating,
+  autoUpdate,
+  offset,
+  flip,
+  shift,
+  useHover,
+  useFocus,
+  useDismiss,
+  useRole,
+  useInteractions,
+  arrow,
+} from '@floating-ui/react';
+import type {Placement} from '@floating-ui/react';
+import {useMemo, useRef, useState} from 'react';
+
+interface TooltipOptions {
+  initialOpen?: boolean;
+  placement?: Placement;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export default function useTooltip({
+  initialOpen = false,
+  placement = 'top',
+  open: controlledOpen,
+  onOpenChange: setControlledOpen,
+}: TooltipOptions = {}) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(initialOpen);
+
+  const open = controlledOpen ?? uncontrolledOpen;
+  const setOpen = setControlledOpen ?? setUncontrolledOpen;
+
+  const arrowRef = useRef(null);
+  const data = useFloating({
+    placement,
+    open,
+    onOpenChange: setOpen,
+    whileElementsMounted: autoUpdate,
+    middleware: [
+      offset(5),
+      flip({
+        crossAxis: placement.includes('-'),
+        fallbackAxisSideDirection: 'start',
+        padding: 5,
+      }),
+      shift({padding: 5}),
+      arrow({
+        element: arrowRef,
+      }),
+    ],
+  });
+
+  const context = data.context;
+
+  const hover = useHover(context, {
+    move: false,
+    enabled: controlledOpen == null,
+  });
+  const focus = useFocus(context, {
+    enabled: controlledOpen == null,
+  });
+  const dismiss = useDismiss(context);
+  const role = useRole(context, {role: 'tooltip'});
+
+  const interactions = useInteractions([hover, focus, dismiss, role]);
+
+  return useMemo(
+    () => ({
+      arrowRef,
+      open,
+      setOpen,
+      ...interactions,
+      ...data,
+    }),
+    [open, setOpen, interactions, data]
+  );
+}

--- a/src/lib/components/project/ProjectIcon.tsx
+++ b/src/lib/components/project/ProjectIcon.tsx
@@ -1,3 +1,4 @@
+import {Tooltip, TooltipContent, TooltipTrigger} from 'toolbar/components/base/tooltip/Tooltip';
 import PlatformIcon from 'toolbar/components/icon/PlatformIcon';
 import useFetchSentryData from 'toolbar/hooks/fetch/useFetchSentryData';
 import {useProjectQuery} from 'toolbar/sentryApi/queryKeys';
@@ -13,5 +14,12 @@ export default function ProjectIcon({size, organizationSlug, projectIdOrSlug}: P
     ...useProjectQuery(String(organizationSlug), String(projectIdOrSlug)),
   });
 
-  return <PlatformIcon size={size} isLoading={!isSuccess} platform={data?.json.platform ?? 'default'} />;
+  return (
+    <Tooltip>
+      <TooltipTrigger>
+        <PlatformIcon size={size} isLoading={!isSuccess} platform={data?.json.platform ?? 'default'} />
+      </TooltipTrigger>
+      <TooltipContent>{data?.json.name}</TooltipContent>
+    </Tooltip>
+  );
 }

--- a/src/lib/mount.tsx
+++ b/src/lib/mount.tsx
@@ -8,14 +8,13 @@ import type {Configuration} from 'toolbar/types/config';
 import {localeTimeRelativeAbbr} from 'toolbar/utils/locale';
 
 export default function mount(rootNode: HTMLElement, config: Configuration) {
+  const cleanup: (() => void)[] = [];
   const {host, reactMount, portalMount} = buildDom(config);
 
   setDefaultOptions({locale: localeTimeRelativeAbbr});
 
-  const cleanup = [
-    setColorScheme(reactMount, config.theme ?? 'system'),
-    setColorScheme(portalMount, config.theme ?? 'system'),
-  ];
+  cleanup.push(setColorScheme(reactMount, config.theme ?? 'system'));
+  cleanup.push(setColorScheme(portalMount, config.theme ?? 'system'));
 
   const reactRoot = createRoot(reactMount);
   reactRoot.render(
@@ -25,12 +24,10 @@ export default function mount(rootNode: HTMLElement, config: Configuration) {
       </Providers>
     </StrictMode>
   );
-  cleanup.push(() => {
+  cleanup.push(() =>
     // `setTimeout` helps to avoid "Attempted to synchronously unmount a root while React was already rendering."
-    setTimeout(() => {
-      reactRoot.unmount();
-    }, 0);
-  });
+    setTimeout(() => reactRoot.unmount(), 0)
+  );
 
   rootNode.appendChild(host);
   cleanup.push(() => host.remove());

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,3 @@
-/* eslint-disable filename-export/match-default-export */
-// const defaultTheme = require('tailwindcss/defaultTheme');
-
 /** @type {import('tailwindcss').Config} */
 const tailwind_config = {
   content: ['./index.html', './src/**/*.tsx'],
@@ -12,7 +9,9 @@ const tailwind_config = {
 
       zIndex: {
         initial: 1,
-        debug: 9999,
+        debug: 9_999,
+        portal: 10_000,
+        tooltip: 10_001,
       },
 
       icon: {


### PR DESCRIPTION
This adapts the docs from https://floating-ui.com/docs/tooltip and https://floating-ui.com/docs/floatingarrow and also pulled in the styles from sentry to get tooltips rendering. The api is a little different from sentry `<Tooltip title="trigger">content</Tooltip>` vs. `<Tooltip><TooltipTrigger>trigger</TooltipTrigger><TooltipContent>content</TooltipContent></Tooltip>`. I think the more verbose api will be fine, just have to include tooltips in more composite components like ProjectIcon and not so often use it in huge view-like things.

<img width="199" alt="SCR-20241127-oxhz" src="https://github.com/user-attachments/assets/431ebc50-4d93-4b15-bf40-dc494089ce98">

I then applied them to the `<ProjectIcon>` component, which looks like this when they're all active:
<img width="274" alt="SCR-20241127-ownf" src="https://github.com/user-attachments/assets/437100c0-e447-4ad2-a337-d747c4a9c7de">

Along the way I had to add the `data-theme` to our `portalMount` div, but inside the storybook the tooltip gets mounted into the `body` inside the iframe, so it's a little different in there, but works out of the box.