### PR TITLE
fix: Improve types of useTooltip()

### DIFF
--- a/src/lib/components/base/tooltip/useTooltip.ts
+++ b/src/lib/components/base/tooltip/useTooltip.ts
@@ -12,13 +12,14 @@ import {
   arrow,
 } from '@floating-ui/react';
 import type {Placement} from '@floating-ui/react';
+import type {MutableRefObject} from 'react';
 import {useMemo, useRef, useState} from 'react';
 
 interface TooltipOptions {
   initialOpen?: boolean;
   placement?: Placement;
   open?: boolean;
-  onOpenChange?: (open: boolean) => void;
+  onOpenChange?: (isOpen: boolean) => void;
 }
 
 export default function useTooltip({
@@ -26,7 +27,12 @@ export default function useTooltip({
   placement = 'top',
   open: controlledOpen,
   onOpenChange: setControlledOpen,
-}: TooltipOptions = {}) {
+}: TooltipOptions = {}): {
+  arrowRef: MutableRefObject<null>;
+  open: boolean;
+  setOpen: (isOpen: boolean) => void;
+} & ReturnType<typeof useInteractions> &
+  ReturnType<typeof useFloating> {
   const [uncontrolledOpen, setUncontrolledOpen] = useState(initialOpen);
 
   const open = controlledOpen ?? uncontrolledOpen;


### PR DESCRIPTION
Before the build was reporting:
```
rc/lib/components/base/tooltip/useTooltip.ts:24:25 - error TS2742: The inferred type of 'useTooltip' cannot be named without a reference to '.pnpm/@floating-ui+react-dom@2.1.2_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@floating-ui/react-dom'. This is likely not portable. A type annotation is necessary.

24 export default function useTooltip({
                           ~~~~~~~~~~
```

So now we have explicit types on that function.