### PR TITLE
fix: Return the debug field after fixing up the values

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -39,4 +39,5 @@ function hydrateDebug(debug: InitConfig['debug']): Configuration['debug'] {
       enabled.push(target);
     }
   });
+  return enabled;
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,43 +1,15 @@
 import mount from 'toolbar/mount';
-import {DebugTarget, type Configuration} from 'toolbar/types/config';
+import type {InitConfig as iInitConfig} from 'toolbar/types/config';
+import hydrateConfig from 'toolbar/utils/hydrateConfig';
 
-export interface InitConfig extends Omit<Configuration, 'debug'> {
-  mountPoint?: HTMLElement | (() => HTMLElement);
-
-  debug: undefined | string;
-}
+// Public facing types:
+export type InitConfig = iInitConfig;
 export type Cleanup = () => void;
 
+// Public functions:
 export function init(initConfig: InitConfig): Cleanup {
   const {mountPoint} = initConfig;
   const root = typeof mountPoint === 'function' ? mountPoint() : mountPoint;
 
   return mount(root ?? document.body, hydrateConfig(initConfig));
-}
-
-function hydrateConfig(config: InitConfig): Configuration {
-  return {
-    ...config,
-    debug: hydrateDebug(config.debug),
-  };
-}
-
-function hydrateDebug(debug: InitConfig['debug']): Configuration['debug'] {
-  if (debug === undefined || debug === 'false' || debug === '') {
-    return [];
-  }
-  const parts = debug?.split(',');
-  const debugTargets = Object.values(DebugTarget);
-
-  if (parts.includes('all') || parts.includes('true')) {
-    return debugTargets;
-  }
-
-  const enabled: NonNullable<Configuration['debug']> = [];
-  debugTargets.forEach(target => {
-    if (parts.includes(target)) {
-      enabled.push(target);
-    }
-  });
-  return enabled;
 }

--- a/src/lib/types/config.ts
+++ b/src/lib/types/config.ts
@@ -97,3 +97,9 @@ interface DebugConfig {
 export interface Configuration extends ConnectionConfig, FeatureFlagsConfig, OrgConfig, RenderConfig, DebugConfig {
   trackAnalytics?: (props: {eventKey: string; eventName: string}) => void;
 }
+
+export interface InitConfig extends Omit<Configuration, 'debug'> {
+  mountPoint?: HTMLElement | (() => HTMLElement);
+
+  debug: undefined | string;
+}

--- a/src/lib/utils/hydrateConfig.spec.ts
+++ b/src/lib/utils/hydrateConfig.spec.ts
@@ -1,0 +1,69 @@
+import {DebugTarget, type InitConfig} from 'toolbar/types/config';
+import hydrateConfig from 'toolbar/utils/hydrateConfig';
+
+function mockInitConfig(overrides: Partial<InitConfig>): InitConfig {
+  return {
+    debug: undefined,
+    environment: '',
+    mountPoint: () => document.createElement('div'),
+    organizationSlug: '',
+    placement: 'right-edge',
+    projectIdOrSlug: '',
+    sentryApiPath: undefined,
+    sentryOrigin: '',
+    ...overrides,
+  };
+}
+
+describe('hydrateConfig', () => {
+  it('should return all Configuration fields, without the extra InitConfig stuff', () => {
+    const initConfig = mockInitConfig({});
+
+    const config = hydrateConfig(initConfig);
+    expect(config).toEqual({
+      debug: [],
+      environment: '',
+      organizationSlug: '',
+      placement: 'right-edge',
+      projectIdOrSlug: '',
+      sentryApiPath: undefined,
+      sentryOrigin: '',
+    });
+  });
+
+  describe('.debug', () => {
+    it('should convert "falsey" values into the empty array', () => {
+      expect(hydrateConfig(mockInitConfig({})).debug).toEqual([]);
+      expect(hydrateConfig(mockInitConfig({debug: 'false'})).debug).toEqual([]);
+      expect(hydrateConfig(mockInitConfig({debug: ''})).debug).toEqual([]);
+    });
+
+    it('should convert "all" and "true" to enable everything', () => {
+      expect(hydrateConfig(mockInitConfig({debug: 'all'})).debug).toEqual(Object.values(DebugTarget));
+      expect(hydrateConfig(mockInitConfig({debug: 'true'})).debug).toEqual(Object.values(DebugTarget));
+      expect(hydrateConfig(mockInitConfig({debug: 'logging,true,state'})).debug).toEqual(Object.values(DebugTarget));
+      expect(hydrateConfig(mockInitConfig({debug: 'all,true,foo,bar'})).debug).toEqual(Object.values(DebugTarget));
+    });
+
+    it('should convert a comma separated list of targets to their enum values', () => {
+      expect(hydrateConfig(mockInitConfig({debug: 'logging'})).debug).toEqual([DebugTarget.LOGGING]);
+      expect(hydrateConfig(mockInitConfig({debug: 'logging,state'})).debug).toEqual([
+        DebugTarget.LOGGING,
+        DebugTarget.STATE,
+      ]);
+      expect(hydrateConfig(mockInitConfig({debug: 'logging, state,    settings'})).debug).toEqual([
+        DebugTarget.LOGGING,
+        DebugTarget.SETTINGS,
+        DebugTarget.STATE,
+      ]);
+    });
+
+    it('should ignore unknown values', () => {
+      expect(hydrateConfig(mockInitConfig({debug: 'logging,foo'})).debug).toEqual([DebugTarget.LOGGING]);
+      expect(hydrateConfig(mockInitConfig({debug: 'logging,foo,state,bar'})).debug).toEqual([
+        DebugTarget.LOGGING,
+        DebugTarget.STATE,
+      ]);
+    });
+  });
+});

--- a/src/lib/utils/hydrateConfig.ts
+++ b/src/lib/utils/hydrateConfig.ts
@@ -1,0 +1,29 @@
+import type {InitConfig} from 'toolbar/types/config';
+import {DebugTarget, type Configuration} from 'toolbar/types/config';
+
+export default function hydrateConfig({mountPoint, ...config}: InitConfig): Configuration {
+  return {
+    ...config,
+    debug: hydrateDebug(config.debug),
+  };
+}
+
+function hydrateDebug(debug: InitConfig['debug']): Configuration['debug'] {
+  if (debug === undefined || debug === 'false' || debug === '') {
+    return [];
+  }
+  const parts = debug?.split(',').map(part => part.trim());
+  const debugTargets = Object.values(DebugTarget);
+
+  if (parts.includes('all') || parts.includes('true')) {
+    return debugTargets;
+  }
+
+  const enabled: NonNullable<Configuration['debug']> = [];
+  debugTargets.forEach(target => {
+    if (parts.includes(target)) {
+      enabled.push(target);
+    }
+  });
+  return enabled;
+}


### PR DESCRIPTION
It `config.debug` was `undefined` at all times before this :(

Now it's a proper array and we can toggle different types of debug areas!