### PR TITLE
feat: Iterate on ApiProxy to keep login/logout message off the MessageChannel

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -5,7 +5,6 @@ import localStorage from 'toolbar/utils/localStorage';
 
 const baseConfig = {
   sentryOrigin: 'http://localhost:8080',
-  sentryApiPath: '/api/0',
 
   // FeatureFlagsConfig
   featureFlags: undefined,

--- a/docs/conditional-script.md
+++ b/docs/conditional-script.md
@@ -119,7 +119,6 @@ function MyReactApp() {
 
       // ConnectionConfig
       sentryOrigin: 'https://sentry.sentry.io',
-      sentryApiPath: '/api/0',
 
       // FeatureFlagsConfig
       featureFlags: undefined,

--- a/src/env/demo/App.tsx
+++ b/src/env/demo/App.tsx
@@ -12,7 +12,6 @@ export default function App() {
 
       // ConnectionConfig -> See .env.example for defaults
       sentryOrigin: import.meta.env.VITE_SENTRY_ORIGIN ?? 'http://localhost:8080',
-      sentryApiPath: import.meta.env.VITE_SENTRY_API_PATH ?? '/region/us/api/0',
 
       // FeatureFlagsConfig
       featureFlags: MockFeatureFlagIntegration(),

--- a/src/lib/components/Navigation.tsx
+++ b/src/lib/components/Navigation.tsx
@@ -85,7 +85,7 @@ export default function Navigation() {
 
         <hr className={menuSeparator} />
 
-        <MenuItem label="logout" onClick={() => apiProxy.exec(new AbortController().signal, 'clear-authn', [])}>
+        <MenuItem label="logout" onClick={() => apiProxy.logout()}>
           <div className={iconItemClass}>
             <IconLock size="sm" isLocked={false} />
             Logout

--- a/src/lib/components/unauth/Login.tsx
+++ b/src/lib/components/unauth/Login.tsx
@@ -11,6 +11,8 @@ const buttonClass = cx('rounded-full p-1 hover:bg-gray-500 hover:underline');
 
 export default function Login() {
   const {debug} = useContext(ConfigContext);
+  const debugLoginSuccess = debug?.includes(DebugTarget.LOGIN_SUCCESS);
+
   const apiProxy = useApiProxyInstance();
 
   const [isLoggingIn, setIsLoggingIn] = useState(false);
@@ -29,9 +31,7 @@ export default function Login() {
   const openPopup = useCallback(() => {
     setIsLoggingIn(true);
 
-    const signal = new AbortController().signal;
-
-    apiProxy.exec(signal, 'request-authn', debug?.includes(DebugTarget.LOGIN_SUCCESS) ? [] : [3000]);
+    apiProxy.login(debugLoginSuccess ? undefined : 3000);
 
     // start timer, after a sec ask about popups
     if (timeoutRef.current) {
@@ -40,7 +40,7 @@ export default function Login() {
     timeoutRef.current = window.setTimeout(() => {
       setShowPopupBlockerMessage(true);
     }, POPUP_MESSAGE_DELAY_MS);
-  }, [apiProxy, debug]);
+  }, [apiProxy, debugLoginSuccess]);
 
   return (
     <UnauthPill>

--- a/src/lib/context/ApiProxyContext.tsx
+++ b/src/lib/context/ApiProxyContext.tsx
@@ -46,13 +46,20 @@ export function ApiProxyContextProvider({children}: Props) {
     };
   }, [config, log]);
 
+  useEffect(() => {
+    if (proxyState !== lastProxyState) {
+      proxyRef.current.disposePort();
+    }
+  });
+
   const frameSrc = `${getSentryIFrameOrigin(config)}/toolbar/${organizationSlug}/${projectIdOrSlug}/iframe/?logging=${enableLogging ? 1 : 0}`;
 
+  log('Render with state', {proxyState});
   return (
     <ApiProxyContext.Provider value={proxyRef.current}>
       <ApiProxyStateContext.Provider value={proxyState}>
         <iframe
-          key={lastProxyState}
+          key={proxyState}
           referrerPolicy="origin"
           height="0"
           width="0"

--- a/src/lib/context/__mocks__/defaultConfig.ts
+++ b/src/lib/context/__mocks__/defaultConfig.ts
@@ -3,7 +3,6 @@ import type {Configuration} from 'toolbar/types/config';
 const defaultConfig: Configuration = {
   // ConnectionConfig
   sentryOrigin: 'https://sentry.io',
-  sentryApiPath: '/api/0',
 
   // FeatureFlagsConfig
   featureFlags: undefined,

--- a/src/lib/context/defaultConfig.ts
+++ b/src/lib/context/defaultConfig.ts
@@ -3,7 +3,6 @@ import type {Configuration} from 'toolbar/types/config';
 const defaultConfig: Configuration = {
   // ConnectionConfig
   sentryOrigin: 'https://test.sentry.io',
-  sentryApiPath: '/api/0',
 
   // FeatureFlagsConfig
   featureFlags: undefined,

--- a/src/lib/hooks/usePrevious.spec.ts
+++ b/src/lib/hooks/usePrevious.spec.ts
@@ -1,0 +1,30 @@
+import {renderHook} from '@testing-library/react';
+import usePrevious from 'toolbar/hooks/usePrevious';
+
+describe('usePrevious', () => {
+  it('stores initial value', () => {
+    const {result} = renderHook(usePrevious, {initialProps: 'Initial Value'});
+    expect(result.current).toBe('Initial Value');
+  });
+
+  it('provides initial value', () => {
+    const {result} = renderHook(usePrevious, {
+      initialProps: 'Initial Value',
+    });
+
+    expect(result.current).toBe('Initial Value');
+  });
+
+  it('provides previous value', () => {
+    const {result, rerender} = renderHook(usePrevious<string | undefined>, {
+      initialProps: undefined,
+    });
+
+    rerender('New Value');
+    // We did not pass anything under initialProps
+    expect(result.current).toBe(undefined);
+    rerender('New New Value');
+    // Result should point to old value
+    expect(result.current).toBe('New Value');
+  });
+});

--- a/src/lib/hooks/usePrevious.ts
+++ b/src/lib/hooks/usePrevious.ts
@@ -1,0 +1,23 @@
+import {useEffect, useRef} from 'react';
+
+/**
+ * Provides previous prop or state inside of function components.
+ * It’s possible that in the future React will provide a usePrevious Hook out of the box since it’s a relatively common use case.
+ * @see {@link https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state}
+ *
+ * @returns 'ref.current' and therefore should not be used as a dependency of useEffect.
+ * Mutable values like 'ref.current' are not valid dependencies of useEffect because changing them does not re-render the component.
+ */
+function usePrevious<T>(value: T): T {
+  // The ref object is a generic container whose current property is mutable ...
+  // ... and can hold any value, similar to an instance property on a class
+  const ref = useRef<T>(value);
+  // Store current value in ref
+  useEffect(() => {
+    ref.current = value;
+  }, [value]); // Only re-run if value changes
+  // Return previous value (happens before update in useEffect above)
+  return ref.current;
+}
+
+export default usePrevious;

--- a/src/lib/sentryApi/urls.spec.ts
+++ b/src/lib/sentryApi/urls.spec.ts
@@ -1,22 +1,16 @@
 import defaultConfig from 'toolbar/context/defaultConfig';
-import {getSentryApiBaseUrl, getSentryWebOrigin, getSentryIFrameOrigin} from 'toolbar/sentryApi/urls';
+import {getSentryWebOrigin, getSentryIFrameOrigin} from 'toolbar/sentryApi/urls';
 import type {Configuration} from 'toolbar/types/config';
 
-type TestCase = [
-  string,
-  Partial<Configuration>,
-  {getSentryApiBaseUrl: string; getSentryWebOrigin: string; getSentryIFrameOrigin: string},
-];
+type TestCase = [string, Partial<Configuration>, {getSentryWebOrigin: string; getSentryIFrameOrigin: string}];
 const testCases: TestCase[] = [
   [
     'SaaS config: root',
     {
       sentryOrigin: 'https://sentry.io',
-      sentryApiPath: '/api/0/',
       organizationSlug: 'acme',
     },
     {
-      getSentryApiBaseUrl: 'https://acme.sentry.io/api/0/',
       getSentryWebOrigin: 'https://acme.sentry.io',
       getSentryIFrameOrigin: 'https://acme.sentry.io',
     },
@@ -25,11 +19,9 @@ const testCases: TestCase[] = [
     'SaaS config: subdomain',
     {
       sentryOrigin: 'https://acme.sentry.io',
-      sentryApiPath: '/api/0/',
       organizationSlug: 'acme',
     },
     {
-      getSentryApiBaseUrl: 'https://acme.sentry.io/api/0/',
       getSentryWebOrigin: 'https://acme.sentry.io',
       getSentryIFrameOrigin: 'https://acme.sentry.io',
     },
@@ -38,11 +30,9 @@ const testCases: TestCase[] = [
     'sentry devserver config',
     {
       sentryOrigin: 'https://dev.getsentry.net:8000',
-      sentryApiPath: '/api/0',
       organizationSlug: 'acme',
     },
     {
-      getSentryApiBaseUrl: 'https://dev.getsentry.net:8000/api/0',
       getSentryWebOrigin: 'https://dev.getsentry.net:8000',
       getSentryIFrameOrigin: 'https://dev.getsentry.net:8000',
     },
@@ -51,22 +41,14 @@ const testCases: TestCase[] = [
     'yarn dev:standalone config',
     {
       sentryOrigin: 'http://localhost:8080',
-      sentryApiPath: '/api/0',
       organizationSlug: 'acme',
     },
     {
-      getSentryApiBaseUrl: 'http://localhost:8080/api/0',
       getSentryWebOrigin: 'http://localhost:8080',
       getSentryIFrameOrigin: 'http://localhost:8080',
     },
   ],
 ];
-
-describe('getSentryApiBaseUrl', () => {
-  it.each<TestCase>(testCases)('should get the correct url for api requests: %s', (_title, config, expected) => {
-    expect(getSentryApiBaseUrl({...defaultConfig, ...config})).toBe(expected.getSentryApiBaseUrl);
-  });
-});
 
 describe('getSentryWebOrigin', () => {
   it.each<TestCase>(testCases)('should get the correct url for web requests: %s', (_title, config, expected) => {

--- a/src/lib/sentryApi/urls.ts
+++ b/src/lib/sentryApi/urls.ts
@@ -17,42 +17,6 @@ function isSaasOrigin(hostname: string) {
 }
 
 /**
- * Given a configuration, we want to return the base URL for API calls
- */
-export function getSentryApiBaseUrl(config: Configuration) {
-  const {organizationSlug, sentryOrigin, sentryApiPath} = config;
-
-  const origin = getOrigin(sentryOrigin);
-  if (!origin) {
-    return sentryOrigin;
-  }
-
-  const parts = [origin.protocol, '//'];
-
-  if (isSaasOrigin(origin.hostname)) {
-    // Ignore `${region}.sentry.io` for now, because we don't have support in the iframe.
-    // Instead we'll use the org slug as the subdomain.
-    // What could happen is we read the region on the server-side, and then the
-    // iframe.html template could set the cookie on the correct place, and return
-    // the iframe api-url to the toolbar directly.
-    // The org api response calls it `links.regionUrl`
-    parts.push(`${organizationSlug}.sentry.io`);
-  } else {
-    parts.push(origin.hostname);
-  }
-
-  if (origin.port) {
-    parts.push(`:${origin.port}`);
-  }
-  if (origin.pathname) {
-    parts.push(origin.pathname.replace(/\/$/, ''));
-  }
-
-  parts.push(sentryApiPath ?? '');
-  return parts.join('');
-}
-
-/**
  * Returns an origin with organization subdomain included, if SaaS is detected.
  */
 export function getSentryWebOrigin(config: Configuration) {

--- a/src/lib/types/config.ts
+++ b/src/lib/types/config.ts
@@ -11,18 +11,6 @@ interface ConnectionConfig {
    * Must not have a trailing backslash.
    */
   sentryOrigin: string;
-
-  /**
-   * The path prefix for the api endpoints.
-   *
-   * Example: `/api/0`
-   *
-   * Must not have a trailing backslash.
-   *
-   * You could write API_PATH=/region/us/api/0, and leave REGION blank but
-   * that's discouraged because it's not as clear as using the individual vars.
-   */
-  sentryApiPath: string | undefined;
 }
 
 interface FeatureFlagsConfig {

--- a/src/lib/utils/ApiProxy.spec.ts
+++ b/src/lib/utils/ApiProxy.spec.ts
@@ -30,13 +30,13 @@ describe('ApiProxy', () => {
 
   describe('constructor()', () => {
     it('should have a disabled state by default', () => {
-      const proxy = new ApiProxy(defaultConfig);
+      const proxy = new ApiProxy(defaultConfig, {current: null});
       expect(proxy.state).toEqual('connecting');
     });
 
     it('should listen to window messages after calling listen()', () => {
       const spy = jest.spyOn(window, 'addEventListener');
-      const proxy = new ApiProxy(defaultConfig);
+      const proxy = new ApiProxy(defaultConfig, {current: null});
 
       expect(spy).not.toHaveBeenCalled();
 
@@ -47,11 +47,11 @@ describe('ApiProxy', () => {
 
     it('should callback when status changes', () => {
       const callback = jest.fn();
-      const proxy = new ApiProxy(defaultConfig);
+      const proxy = new ApiProxy(defaultConfig, {current: null});
       proxy.setOnStatusChanged(callback);
 
       // @ts-expect-error: Accessing a private method
-      proxy._updateStatus({
+      proxy.setState({
         hasPort: true,
         isProjectConfigured: true,
       });
@@ -65,7 +65,7 @@ describe('ApiProxy', () => {
   describe('_handleWindowMessage', () => {
     it('should ignore messages without source==="sentry-toolbar"', () => {
       const callback = jest.fn();
-      const proxy = new ApiProxy(defaultConfig);
+      const proxy = new ApiProxy(defaultConfig, {current: null});
       proxy.setOnStatusChanged(callback);
       postMessageToWindow(proxy, {});
 
@@ -78,7 +78,7 @@ describe('ApiProxy', () => {
       const start = jest.spyOn(port, 'start');
 
       const callback = jest.fn();
-      const proxy = new ApiProxy(defaultConfig);
+      const proxy = new ApiProxy(defaultConfig, {current: null});
       proxy.listen();
       proxy.setOnStatusChanged(callback);
       postMessageToWindow(proxy, {source: 'sentry-toolbar', message: 'port-connect'}, [port]);
@@ -88,7 +88,6 @@ describe('ApiProxy', () => {
       // @ts-expect-error: Accessing a private member
       expect(proxy._port).toBeDefined();
       expect(start).toHaveBeenCalled();
-      expect(callback).toHaveBeenCalledWith('logged-out');
     });
 
     it('should cleanup the received port', () => {
@@ -97,11 +96,10 @@ describe('ApiProxy', () => {
       const close = jest.spyOn(port, 'close');
 
       const callback = jest.fn();
-      const proxy = new ApiProxy(defaultConfig);
+      const proxy = new ApiProxy(defaultConfig, {current: null});
       proxy.listen();
       proxy.setOnStatusChanged(callback);
       postMessageToWindow(proxy, {source: 'sentry-toolbar', message: 'port-connect'}, [port]);
-      expect(callback).toHaveBeenCalledWith('logged-out');
 
       proxy.dispose();
 
@@ -121,7 +119,7 @@ describe('ApiProxy', () => {
     it('should resolve cached promises based on the message $result', () => {
       const {responsePort, sendPortConnect} = getPorts();
 
-      const proxy = new ApiProxy(defaultConfig);
+      const proxy = new ApiProxy(defaultConfig, {current: null});
       proxy.listen();
       sendPortConnect(proxy);
       expect(outstandingPromises(proxy).size).toBe(0); // No promises to start
@@ -138,7 +136,7 @@ describe('ApiProxy', () => {
     it('should reject cached promises based on the message $error', () => {
       const {responsePort, sendPortConnect} = getPorts();
 
-      const proxy = new ApiProxy(defaultConfig);
+      const proxy = new ApiProxy(defaultConfig, {current: null});
       proxy.listen();
       sendPortConnect(proxy);
       expect(outstandingPromises(proxy).size).toBe(0); // No promises to start
@@ -155,7 +153,7 @@ describe('ApiProxy', () => {
     it('should handle and ignore malformed messages', () => {
       const {responsePort, sendPortConnect} = getPorts();
 
-      const proxy = new ApiProxy(defaultConfig);
+      const proxy = new ApiProxy(defaultConfig, {current: null});
       proxy.listen();
       sendPortConnect(proxy);
       expect(outstandingPromises(proxy).size).toBe(0); // No promises to start
@@ -175,7 +173,7 @@ describe('ApiProxy', () => {
     it('should ignore messages in reply to an unknown promise', () => {
       const {responsePort, sendPortConnect} = getPorts();
 
-      const proxy = new ApiProxy(defaultConfig);
+      const proxy = new ApiProxy(defaultConfig, {current: null});
       proxy.listen();
       sendPortConnect(proxy);
       expect(outstandingPromises(proxy).size).toBe(0); // No promises to start
@@ -196,7 +194,7 @@ describe('ApiProxy', () => {
       const {responsePort, sendPortConnect} = getPorts();
 
       const abortController = new AbortController();
-      const proxy = new ApiProxy(defaultConfig);
+      const proxy = new ApiProxy(defaultConfig, {current: null});
       proxy.listen();
       sendPortConnect(proxy);
       expect(outstandingPromises(proxy).size).toBe(0); // No promises to start
@@ -215,7 +213,7 @@ describe('ApiProxy', () => {
 
   describe('Send messages: exec', () => {
     it('should drop messaages when the port is not set', () => {
-      const proxy = new ApiProxy(defaultConfig);
+      const proxy = new ApiProxy(defaultConfig, {current: null});
       const promise = proxy.exec(new AbortController().signal, 'log', ['hello world']);
 
       expect(promise).toBeUndefined();
@@ -224,7 +222,7 @@ describe('ApiProxy', () => {
     it('should send sequential messages and cache a promise for later', () => {
       const {responsePort, requestPostMessageSpy, sendPortConnect} = getPorts();
 
-      const proxy = new ApiProxy(defaultConfig);
+      const proxy = new ApiProxy(defaultConfig, {current: null});
       proxy.listen();
       sendPortConnect(proxy);
 
@@ -245,7 +243,7 @@ describe('ApiProxy', () => {
     it('should send fetch messages', () => {
       const {responsePort, requestPostMessageSpy, sendPortConnect} = getPorts();
 
-      const proxy = new ApiProxy(defaultConfig);
+      const proxy = new ApiProxy(defaultConfig, {current: null});
       proxy.listen();
       sendPortConnect(proxy);
 
@@ -262,7 +260,7 @@ describe('ApiProxy', () => {
     it('should resolve promises with the resolved data', () => {
       const {responsePort, requestPostMessageSpy, sendPortConnect} = getPorts();
 
-      const proxy = new ApiProxy(defaultConfig);
+      const proxy = new ApiProxy(defaultConfig, {current: null});
       proxy.listen();
       sendPortConnect(proxy);
 
@@ -280,7 +278,7 @@ describe('ApiProxy', () => {
     it('should reject promises with the error object', () => {
       const {responsePort, requestPostMessageSpy, sendPortConnect} = getPorts();
 
-      const proxy = new ApiProxy(defaultConfig);
+      const proxy = new ApiProxy(defaultConfig, {current: null});
       proxy.listen();
       sendPortConnect(proxy);
 

--- a/src/lib/utils/ApiProxy.ts
+++ b/src/lib/utils/ApiProxy.ts
@@ -75,11 +75,11 @@ export default class ApiProxy {
   public dispose() {
     this._log('dispose()');
     window.removeEventListener('message', this._handleWindowMessage);
-    this._disposePort();
+    this.disposePort();
     this.setState('connecting');
   }
 
-  private _disposePort() {
+  public disposePort() {
     this._log('disposePort()');
     this._port?.removeEventListener('message', this._handlePortMessage);
     this._port?.close();
@@ -108,7 +108,6 @@ export default class ApiProxy {
       case 'invalid-domain': // fallthrough
       case 'logged-in': // fallthrough
       case 'stale':
-        this._disposePort();
         this.setState(event.data.message);
         break;
       case 'port-connect': {

--- a/src/lib/utils/hydrateConfig.spec.ts
+++ b/src/lib/utils/hydrateConfig.spec.ts
@@ -9,7 +9,6 @@ function mockInitConfig(overrides: Partial<InitConfig>): InitConfig {
     organizationSlug: '',
     placement: 'right-edge',
     projectIdOrSlug: '',
-    sentryApiPath: undefined,
     sentryOrigin: '',
     ...overrides,
   };
@@ -26,7 +25,6 @@ describe('hydrateConfig', () => {
       organizationSlug: '',
       placement: 'right-edge',
       projectIdOrSlug: '',
-      sentryApiPath: undefined,
       sentryOrigin: '',
     });
   });


### PR DESCRIPTION
Related to: https://github.com/getsentry/sentry/pull/81942

Changes:
- The `request-login` and `request-logout` messages are going over `iframe.contentWindow.postMessage()` now. The MessagePort is reserved for when the iframe is logged in and properly configured.
- When state _changes_ we dispose of any ports (would only been connected if we were previously logged in) and reload the iframe. This ensures that we get a new state told to us from the html file
- We've dropped the `sentryApiPath` config value, because the config endpoint (domain, region if needed, and this prefix) is set inside the iframe js scripts. The `fetch` command of the proxy can only make fetch requests to the sentry api now, not to other domains.