### PR TITLE
ref: show all issues and feedbacks

### DIFF
--- a/src/lib/components/panels/feedback/FeedbackListItem.tsx
+++ b/src/lib/components/panels/feedback/FeedbackListItem.tsx
@@ -86,7 +86,7 @@ function FeedbackProject({item}: {item: FeedbackIssueListItem}) {
   return (
     <div className="flex flex-row items-center gap-0.5">
       <ProjectIcon size="xs" organizationSlug={organizationSlug} projectIdOrSlug={projectIdOrSlug} />
-      <span className="truncate text-xs">{item.shortId}</span>;
+      <span className="truncate text-xs">{item.shortId}</span>
     </div>
   );
 }

--- a/src/lib/components/panels/feedback/FeedbackPanel.tsx
+++ b/src/lib/components/panels/feedback/FeedbackPanel.tsx
@@ -8,16 +8,16 @@ import ProjectIcon from 'toolbar/components/project/ProjectIcon';
 import SentryAppLink from 'toolbar/components/SentryAppLink';
 import ConfigContext from 'toolbar/context/ConfigContext';
 import useFetchSentryData from 'toolbar/hooks/fetch/useFetchSentryData';
-import useCurrentSentryTransactionName from 'toolbar/hooks/useCurrentSentryTransactionName';
 import {useMembersQuery, useTeamsQuery} from 'toolbar/sentryApi/queryKeys';
 import type {FeedbackIssueListItem} from 'toolbar/sentryApi/types/group';
 
 export default function FeedbackPanel() {
   const {organizationSlug, projectIdOrSlug} = useContext(ConfigContext);
 
-  const transactionName = useCurrentSentryTransactionName();
+  // const transactionName = useCurrentSentryTransactionName();
   const queryResult = useInfiniteFeedbackList({
-    query: transactionName ? `transaction:${transactionName}` : '',
+    // query: transactionName ? `transaction:${transactionName}` : '',
+    query: '',
   });
   const {data: members} = useFetchSentryData({
     ...useMembersQuery(String(organizationSlug), String(projectIdOrSlug)),

--- a/src/lib/components/panels/issues/IssuesPanel.tsx
+++ b/src/lib/components/panels/issues/IssuesPanel.tsx
@@ -8,16 +8,16 @@ import ProjectIcon from 'toolbar/components/project/ProjectIcon';
 import SentryAppLink from 'toolbar/components/SentryAppLink';
 import ConfigContext from 'toolbar/context/ConfigContext';
 import useFetchSentryData from 'toolbar/hooks/fetch/useFetchSentryData';
-import useCurrentSentryTransactionName from 'toolbar/hooks/useCurrentSentryTransactionName';
 import {useMembersQuery, useTeamsQuery} from 'toolbar/sentryApi/queryKeys';
 import type {Group} from 'toolbar/sentryApi/types/group';
 
 export default function IssuesPanel() {
   const {organizationSlug, projectIdOrSlug} = useContext(ConfigContext);
 
-  const transactionName = useCurrentSentryTransactionName();
+  // const transactionName = useCurrentSentryTransactionName();
   const queryResult = useInfiniteIssuesList({
-    query: transactionName ? `transaction:${transactionName}` : '',
+    // query: transactionName ? `transaction:${transactionName}` : '',
+    query: '',
   });
   const {data: members} = useFetchSentryData({
     ...useMembersQuery(String(organizationSlug), String(projectIdOrSlug)),


### PR DESCRIPTION
Currently, using the transaction name to show issues and feedbacks related to a page doesn't work well. We will show all results for now as this is needed for our demo pictures until we come up with a better solution.

Also fixed a typo