### PR TITLE
fix: Use url when querying for feedbacks

### DIFF
--- a/src/lib/components/panels/feedback/FeedbackPanel.tsx
+++ b/src/lib/components/panels/feedback/FeedbackPanel.tsx
@@ -17,7 +17,7 @@ export default function FeedbackPanel() {
 
   const transactionName = useCurrentSentryTransactionName();
   const queryResult = useInfiniteFeedbackList({
-    query: transactionName ? `transaction:${transactionName}` : '',
+    query: transactionName ? `url:${transactionName}` : '',
   });
   const {data: members} = useFetchSentryData({
     ...useMembersQuery(String(organizationSlug), String(projectIdOrSlug)),


### PR DESCRIPTION
Querying for feedbacks using `transaction` doesn't return any results, so we need to switch back to using `url`