### PR TITLE
ref: Replace framer-motion with Transition from headlessui

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,12 +57,12 @@
   },
   "dependencies": {
     "@floating-ui/react": "^0.26.24",
+    "@headlessui/react": "^2.2.0",
     "@sentry/types": "^8.30.0",
     "@tanstack/react-query": "^5.56.2",
     "@tanstack/react-virtual": "^3.10.8",
     "cva": "npm:class-variance-authority@^0.7.0",
     "date-fns": "^4.1.0",
-    "framer-motion": "^11.7.0",
     "platformicons": "^7.0.1",
     "query-string": "^9.1.0",
     "react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@floating-ui/react':
         specifier: ^0.26.24
         version: 0.26.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@headlessui/react':
+        specifier: ^2.2.0
+        version: 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sentry/types':
         specifier: ^8.30.0
         version: 8.30.0
@@ -26,9 +29,6 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
-      framer-motion:
-        specifier: ^11.7.0
-        version: 11.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       platformicons:
         specifier: ^7.0.1
         version: 7.0.1(react@18.3.1)
@@ -1497,6 +1497,13 @@ packages:
 
   '@formatjs/intl-localematcher@0.5.4':
     resolution: {integrity: sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==}
+
+  '@headlessui/react@2.2.0':
+    resolution: {integrity: sha512-RzCEg+LXsuI7mHiSomsu/gBJSjpupm6A1qIZ5sWjd7JhARNlMiSA4kKfJpCKwU9tE+zMRterhhrP74PvfJrpXQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -4236,20 +4243,6 @@ packages:
   fragment-cache@0.2.1:
     resolution: {integrity: sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==}
     engines: {node: '>=0.10.0'}
-
-  framer-motion@11.7.0:
-    resolution: {integrity: sha512-m+1E3mMzDIQ5DsVghMvXyC+jSkZSm5RHBLA2gHa/LczcXwW6JbQK4Uz48LsuCTGV8bZFVUezcauHj3M33tY/5w==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^18.0.0
-      react-dom: ^18.0.0
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
@@ -8518,6 +8511,15 @@ snapshots:
     dependencies:
       tslib: 2.7.0
 
+  '@headlessui/react@2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react': 0.26.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/focus': 3.18.2(react@18.3.1)
+      '@react-aria/interactions': 3.22.2(react@18.3.1)
+      '@tanstack/react-virtual': 3.10.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.3.0': {}
@@ -12168,13 +12170,6 @@ snapshots:
   fragment-cache@0.2.1:
     dependencies:
       map-cache: 0.2.2
-
-  framer-motion@11.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      tslib: 2.7.0
-    optionalDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
 
   fresh@0.5.2: {}
 

--- a/src/lib/components/Navigation.tsx
+++ b/src/lib/components/Navigation.tsx
@@ -1,6 +1,6 @@
+import {Transition} from '@headlessui/react';
 import {cx} from 'cva';
-import {motion} from 'framer-motion';
-import {Fragment, useContext} from 'react';
+import {useContext} from 'react';
 import type {MouseEvent} from 'react';
 import {NavLink, useLocation, useNavigate} from 'react-router-dom';
 import type {To} from 'react-router-dom';
@@ -62,13 +62,9 @@ export default function Navigation() {
   });
 
   return (
-    <motion.div
-      layout="position"
-      className={navClassName}
-      onMouseOver={() => setIsHovered(true)}
-      onMouseOut={() => setIsHovered(false)}>
+    <div className={navClassName} onMouseOver={() => setIsHovered(true)} onMouseOut={() => setIsHovered(false)}>
       <Tooltip>
-        <TooltipTrigger>
+        <TooltipTrigger asChild>
           <Menu className={cx(navItemClassName, 'p-0')} trigger={<IconSentry size="sm" />} placement="left-start">
             <MenuItem label="pin" onClick={() => setIsPinned(!isPinned)}>
               <div className={iconItemClass}>
@@ -99,12 +95,12 @@ export default function Navigation() {
         <TooltipContent>More options</TooltipContent>
       </Tooltip>
 
-      {isExpanded ? (
-        <Fragment>
+      <Transition show={isExpanded}>
+        <div className="transition duration-300 ease-in data-[closed]:opacity-0">
           <hr className={navSeparator} />
 
           <Tooltip>
-            <TooltipTrigger>
+            <TooltipTrigger asChild>
               <NavLink {...toPathOrHome('/issues')} className={navItemClassName}>
                 <IconIssues size="sm" />
               </NavLink>
@@ -113,7 +109,7 @@ export default function Navigation() {
           </Tooltip>
 
           <Tooltip>
-            <TooltipTrigger>
+            <TooltipTrigger asChild>
               <NavLink {...toPathOrHome('/feedback')} className={navItemClassName}>
                 <IconMegaphone size="sm" />
               </NavLink>
@@ -122,15 +118,15 @@ export default function Navigation() {
           </Tooltip>
 
           <Tooltip>
-            <TooltipTrigger>
+            <TooltipTrigger asChild>
               <NavLink {...toPathOrHome('/featureFlags')} className={navItemClassName}>
                 <IconFlag size="sm" />
               </NavLink>
             </TooltipTrigger>
             <TooltipContent>Feature Flags</TooltipContent>
           </Tooltip>
-        </Fragment>
-      ) : null}
-    </motion.div>
+        </div>
+      </Transition>
+    </div>
   );
 }


### PR DESCRIPTION
https://headlessui.com/react/transition

Using `<Transition>` made it easier to have a nice fade in/out animation compared to the size change thing we were trying to do before. Also, it's adding much less to the bundle size. 

Bundle size numbers:
- framermotion added 107kb to the bundle
- i tried something called [auto-animate](https://auto-animate.formkit.com/#plugins), which added 7kb
- this `<Transition>` component added 6kb

While bundle size is not a primary concern for this dev focused build, it's a nice win.