### PR TITLE
feat: Set sentryOrigin default earlier so it appears in UI labels & everywhere

### DIFF
--- a/src/lib/sentryApi/urls.ts
+++ b/src/lib/sentryApi/urls.ts
@@ -20,7 +20,7 @@ function isSaasOrigin(hostname: string) {
  * Returns an origin with organization subdomain included, if SaaS is detected.
  */
 export function getSentryWebOrigin(config: Configuration) {
-  const {sentryOrigin = 'https://sentry.io', organizationSlug} = config;
+  const {sentryOrigin, organizationSlug} = config;
 
   const origin = getOrigin(sentryOrigin);
   if (!origin) {

--- a/src/lib/types/config.ts
+++ b/src/lib/types/config.ts
@@ -4,13 +4,13 @@ interface ConnectionConfig {
   /**
    * The origin where sentry can be found
    *
-   * Default: `"https://acme.sentry.io"`
+   * Default: `"https://sentry.io"`
    *
    * Must include: protocol, domain & port (if non-standard).
    * May include a url path if sentry is not hosted at the domain root.
    * Must not have a trailing backslash.
    */
-  sentryOrigin?: undefined | string;
+  sentryOrigin: string;
 }
 
 interface FeatureFlagsConfig {
@@ -91,8 +91,10 @@ interface DebugConfig {
 
 export interface Configuration extends ConnectionConfig, FeatureFlagsConfig, OrgConfig, RenderConfig, DebugConfig {}
 
-export interface InitConfig extends Omit<Configuration, 'debug' | 'environment'> {
+export interface InitConfig extends Omit<Configuration, 'sentryOrigin' | 'environment' | 'debug'> {
   mountPoint?: undefined | HTMLElement | (() => HTMLElement);
+
+  sentryOrigin?: undefined | string;
 
   // Override environment, because it will be hydrated intentionally.
   environment?: undefined | string | string[];

--- a/src/lib/utils/hydrateConfig.spec.ts
+++ b/src/lib/utils/hydrateConfig.spec.ts
@@ -9,7 +9,7 @@ function mockInitConfig(overrides: Partial<InitConfig>): InitConfig {
     organizationSlug: '',
     placement: 'right-edge',
     projectIdOrSlug: '',
-    sentryOrigin: '',
+    sentryOrigin: undefined,
     ...overrides,
   };
 }
@@ -24,7 +24,27 @@ describe('hydrateConfig', () => {
       organizationSlug: '',
       placement: 'right-edge',
       projectIdOrSlug: '',
-      sentryOrigin: '',
+      sentryOrigin: 'https://sentry.io',
+    });
+  });
+
+  describe('.sentryOrigin', () => {
+    it('should convert undefined and empty string to the default value', () => {
+      expect(hydrateConfig(mockInitConfig({sentryOrigin: undefined})).sentryOrigin).toEqual('https://sentry.io');
+      expect(hydrateConfig(mockInitConfig({sentryOrigin: ''})).sentryOrigin).toEqual('https://sentry.io');
+    });
+
+    it('should accept whatever string is passed in', () => {
+      expect(hydrateConfig(mockInitConfig({sentryOrigin: 'example.com'})).sentryOrigin).toEqual('example.com');
+      expect(hydrateConfig(mockInitConfig({sentryOrigin: 'example.com:8080'})).sentryOrigin).toEqual(
+        'example.com:8080'
+      );
+      expect(hydrateConfig(mockInitConfig({sentryOrigin: 'http://example.com'})).sentryOrigin).toEqual(
+        'http://example.com'
+      );
+      expect(hydrateConfig(mockInitConfig({sentryOrigin: 'http://example.com:8080'})).sentryOrigin).toEqual(
+        'http://example.com:8080'
+      );
     });
   });
 

--- a/src/lib/utils/hydrateConfig.ts
+++ b/src/lib/utils/hydrateConfig.ts
@@ -4,6 +4,7 @@ import {DebugTarget, type Configuration} from 'toolbar/types/config';
 export default function hydrateConfig({mountPoint, ...config}: InitConfig): Configuration {
   return {
     ...config,
+    sentryOrigin: config.sentryOrigin ? String(config.sentryOrigin) : 'https://sentry.io',
     environment: hydrateEnvironment(config.environment),
     placement: hydratePlacement(config.placement),
     debug: hydrateDebug(config.debug),


### PR DESCRIPTION
In some places the `sentryOrigin` shows up in the UI, like the 'Connecting ...' message before login. In this case it's better to have set the default earlier because then it'll render to users and be guaranteed to be the same value that is actually trying to connect.