### PR TITLE
fix: Disable iframe logging

### DIFF
--- a/src/lib/context/ApiProxyContext.tsx
+++ b/src/lib/context/ApiProxyContext.tsx
@@ -52,7 +52,7 @@ export function ApiProxyContextProvider({children}: Props) {
     }
   });
 
-  const frameSrc = `${getSentryIFrameOrigin(config)}/toolbar/${organizationSlug}/${projectIdOrSlug}/iframe/?logging=${enableLogging ? 1 : 0}`;
+  const frameSrc = `${getSentryIFrameOrigin(config)}/toolbar/${organizationSlug}/${projectIdOrSlug}/iframe/?logging=${enableLogging ? '1' : ''}`;
 
   log('Render with state', {proxyState});
   return (

--- a/src/lib/types/config.ts
+++ b/src/lib/types/config.ts
@@ -100,5 +100,5 @@ export interface InitConfig extends Omit<Configuration, 'sentryOrigin' | 'enviro
   environment?: undefined | string | string[];
 
   // Override debug, because it will be hydrated intentionally.
-  debug?: undefined | string;
+  debug?: undefined | string | boolean;
 }

--- a/src/lib/utils/hydrateConfig.spec.ts
+++ b/src/lib/utils/hydrateConfig.spec.ts
@@ -90,11 +90,13 @@ describe('hydrateConfig', () => {
       expect(hydrateConfig(mockInitConfig({debug: ''})).debug).toEqual([]);
     });
 
-    it('should convert "all" and "true" to enable everything', () => {
-      expect(hydrateConfig(mockInitConfig({debug: 'all'})).debug).toEqual(Object.values(DebugTarget));
-      expect(hydrateConfig(mockInitConfig({debug: 'true'})).debug).toEqual(Object.values(DebugTarget));
-      expect(hydrateConfig(mockInitConfig({debug: 'logging,true,state'})).debug).toEqual(Object.values(DebugTarget));
-      expect(hydrateConfig(mockInitConfig({debug: 'all,true,foo,bar'})).debug).toEqual(Object.values(DebugTarget));
+    it('should convert `"all"`, `"true"` and `true` to enable everything', () => {
+      const allTargets = Object.values(DebugTarget);
+      expect(hydrateConfig(mockInitConfig({debug: 'all'})).debug).toEqual(allTargets);
+      expect(hydrateConfig(mockInitConfig({debug: 'true'})).debug).toEqual(allTargets);
+      expect(hydrateConfig(mockInitConfig({debug: true})).debug).toEqual(allTargets);
+      expect(hydrateConfig(mockInitConfig({debug: 'logging,true,state'})).debug).toEqual(allTargets);
+      expect(hydrateConfig(mockInitConfig({debug: 'all,true,foo,bar'})).debug).toEqual(allTargets);
     });
 
     it('should convert a comma separated list of targets to their enum values', () => {

--- a/src/lib/utils/hydrateConfig.ts
+++ b/src/lib/utils/hydrateConfig.ts
@@ -30,9 +30,11 @@ function hydrateDebug(debug: InitConfig['debug']): Configuration['debug'] {
   if (!debug || debug === 'false') {
     return [];
   }
-  const parts = debug.split(',').map(part => part.trim());
   const debugTargets = Object.values(DebugTarget);
-
+  if (debug === true) {
+    return debugTargets;
+  }
+  const parts = debug.split(',').map(part => part.trim());
   if (parts.includes('all') || parts.includes('true')) {
     return debugTargets;
   }


### PR DESCRIPTION
Before the `0` was being put on the url and converted to a string, where python found it and turned it back into `"0"` which is now a truthy thing.

So we just need `""` to go into the url and be passed around.