### PR TITLE
ref: Refactor setColorScheme to reuse in stories

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -17,10 +17,6 @@ const main: StorybookConfig = {
   typescript: {
     reactDocgen: 'react-docgen-typescript',
   },
-  previewBody: body => `
-    ${body}
-    <script>document.body.dataset.theme = 'light';</script>
-  `,
 };
 
 export default main;

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,6 +3,7 @@ import '../src/lib/index.css';
 import Providers from 'toolbar/context/Providers';
 import type {Configuration} from 'toolbar/types/config';
 import localStorage from 'toolbar/utils/localStorage';
+import setColorScheme from 'toolbar/utils/setColorScheme';
 
 const baseConfig: Configuration = {
   sentryOrigin: 'http://localhost:8080',
@@ -26,11 +27,10 @@ const baseConfig: Configuration = {
 
 const preview: Preview = {
   decorators: [
-    (Story, {parameters: {theme}}) => (
-      <div data-theme={theme} style={{background: theme === 'dark' ? 'var(--white)' : undefined}}>
-        <Story />
-      </div>
-    ),
+    (Story, {parameters: {config}}) => {
+      setColorScheme(document.body, config.theme);
+      return <Story />;
+    },
     (Story, {parameters: {config}}) => (
       <Providers config={config} portalMount={document.body}>
         <Story />
@@ -50,7 +50,6 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
-    theme: 'light',
     config: baseConfig,
   },
 };

--- a/src/lib/index.css
+++ b/src/lib/index.css
@@ -64,10 +64,10 @@
     --white: #1d1127;
 
     /* Surface */
-    --surface100: '#18121c';
-    --surface-200: '#1a141f';
-    --surface-300: '#241d2a';
-    --surface-400: '#2c2433';
+    --surface100: #18121c;
+    --surface-200: #1a141f;
+    --surface-300: #241d2a;
+    --surface-400: #2c2433;
 
     /* Translucent */
     --translucent-gray-200: rgb(218 184 245 / 16%);

--- a/src/lib/mount.tsx
+++ b/src/lib/mount.tsx
@@ -6,6 +6,7 @@ import Providers from 'toolbar/context/Providers';
 import styles from 'toolbar/index.css?inline'; // returned as a string
 import type {Configuration} from 'toolbar/types/config';
 import {localeTimeRelativeAbbr} from 'toolbar/utils/locale';
+import setColorScheme from 'toolbar/utils/setColorScheme';
 
 export default function mount(rootNode: HTMLElement, config: Configuration) {
   const cleanup: (() => void)[] = [];
@@ -60,24 +61,4 @@ function buildDom(config: Configuration) {
   shadow.appendChild(portalMount);
 
   return {host, reactMount, portalMount};
-}
-
-function setColorScheme(host: HTMLDivElement, theme: 'system' | 'light' | 'dark') {
-  if (theme === 'light' || theme === 'dark') {
-    host.dataset.theme = theme;
-    return () => {};
-  } else {
-    if (!window.matchMedia) {
-      host.dataset.theme = 'light';
-      return () => {};
-    } else {
-      const match = window.matchMedia('(prefers-color-scheme: dark)');
-      host.dataset.theme = match.matches ? 'dark' : 'light';
-      const onChange = () => {
-        setColorScheme(host, 'system');
-      };
-      match.addEventListener('change', onChange);
-      return () => match.removeEventListener('change', onChange);
-    }
-  }
 }

--- a/src/lib/utils/setColorScheme.tsx
+++ b/src/lib/utils/setColorScheme.tsx
@@ -1,0 +1,17 @@
+export default function setColorScheme(host: HTMLElement, theme: 'system' | 'light' | 'dark') {
+  if (theme === 'light' || theme === 'dark') {
+    host.dataset.theme = theme;
+    return () => {};
+  }
+  if (!window.matchMedia) {
+    host.dataset.theme = 'light';
+    return () => {};
+  }
+  const match = window.matchMedia('(prefers-color-scheme: dark)');
+  host.dataset.theme = match.matches ? 'dark' : 'light';
+  const onChange = () => {
+    setColorScheme(host, 'system');
+  };
+  match.addEventListener('change', onChange);
+  return () => match.removeEventListener('change', onChange);
+}


### PR DESCRIPTION
Now in stories you can easily switch between light & dark mode using the built-in browser inspect tools

Light: 
<img width="198" alt="SCR-20241216-nexn" src="https://github.com/user-attachments/assets/367c6554-9ca1-4676-8e6e-0eeeea1bf676" />

Dark:

<img width="207" alt="SCR-20241216-ngmn" src="https://github.com/user-attachments/assets/10981af1-3517-46b0-b0a3-b9a6cd68c65f" />
