### PR TITLE
fix: Fix ExternalLink colors within the UnauthPill in dark mode

### DIFF
--- a/src/env/demo/App.tsx
+++ b/src/env/demo/App.tsx
@@ -24,7 +24,7 @@ export default function App() {
       // RenderConfig
       domId: 'sentry-toolbar',
       placement: 'right-edge',
-      theme: 'light',
+      theme: 'system',
 
       // Debug
       debug: import.meta.env.VITE_SENTRY_TOOLBAR_DEBUG,

--- a/src/lib/components/unauth/InvalidDomain.tsx
+++ b/src/lib/components/unauth/InvalidDomain.tsx
@@ -4,7 +4,7 @@ import SentryAppLink from 'toolbar/components/SentryAppLink';
 import UnauthPill from 'toolbar/components/unauth/UnauthPill';
 import ConfigContext from 'toolbar/context/ConfigContext';
 
-const buttonClass = cx('rounded-full text-white p-1 hover:bg-gray-500 hover:underline');
+const buttonClass = cx('rounded-full text-white-raw p-1 hover:bg-gray-500 hover:underline');
 
 export default function InvalidDomain() {
   const config = useContext(ConfigContext);

--- a/src/lib/components/unauth/Login.tsx
+++ b/src/lib/components/unauth/Login.tsx
@@ -7,7 +7,7 @@ import {DebugTarget} from 'toolbar/types/config';
 
 const POPUP_MESSAGE_DELAY_MS = 3_000;
 
-const buttonClass = cx('rounded-full p-1 hover:bg-gray-500 hover:underline');
+const buttonClass = cx('rounded-full text-white-raw p-1 hover:bg-gray-500 hover:underline');
 
 export default function Login() {
   const {debug} = useContext(ConfigContext);

--- a/src/lib/components/unauth/MissingProject.tsx
+++ b/src/lib/components/unauth/MissingProject.tsx
@@ -4,7 +4,7 @@ import SentryAppLink from 'toolbar/components/SentryAppLink';
 import UnauthPill from 'toolbar/components/unauth/UnauthPill';
 import ConfigContext from 'toolbar/context/ConfigContext';
 
-const buttonClass = cx('rounded-full p-1 hover:bg-gray-500 hover:underline');
+const buttonClass = cx('rounded-full text-white-raw p-1 hover:bg-gray-500 hover:underline');
 
 export default function MissingProject() {
   const {projectIdOrSlug} = useContext(ConfigContext);


### PR DESCRIPTION
Light mode always worked, but the link inside the pill was unreadable in dark mode. Fixed now.

**Before:**
| Dark |
| --- |
| <img width="712" alt="SCR-20241217-ssxw" src="https://github.com/user-attachments/assets/5d33b94f-38b5-4a84-8eba-1e37710099c5" />

**After:**
| Dark | Light |
| --- | --- |
| <img width="678" alt="SCR-20241217-stbs" src="https://github.com/user-attachments/assets/291844c5-7465-4854-b1ac-7845b9b88066" /> | <img width="686" alt="SCR-20241217-ssyw" src="https://github.com/user-attachments/assets/6728915c-4c05-4695-94c9-fd1e3d7bda14" />


