### PR TITLE
feat(setup): Pass the host + port to sentry settings page when domain is invalid

### DIFF
--- a/src/lib/components/unauth/InvalidDomain.tsx
+++ b/src/lib/components/unauth/InvalidDomain.tsx
@@ -18,6 +18,9 @@ export default function InvalidDomain() {
           className={buttonClass}
           to={{
             url: `/settings/projects/${projectIdOrSlug}/toolbar/`,
+            query: {
+              domain: window.location.host,
+            },
           }}>
           Configure project
         </SentryAppLink>


### PR DESCRIPTION
This will let sentry know which domain you're trying to use, and show a message to help you save the correct thing into the settings page.
