### PR TITLE
feat(flags): Create an initial, basic, OpenFeature adapter to read feature flags

### DIFF
--- a/mock/flagd/Makefile
+++ b/mock/flagd/Makefile
@@ -1,0 +1,8 @@
+run:
+	docker run \
+		--rm -it \
+		--name flagd \
+		-p 8013:8013 \
+		-v $(shell pwd)/config:/etc/flagd \
+		ghcr.io/open-feature/flagd:latest start \
+		--uri file:/etc/flagd/demo.flagd.json

--- a/mock/flagd/config/demo.flagd.json
+++ b/mock/flagd/config/demo.flagd.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://flagd.dev/schema/v0/flags.json",
+  "flags": {
+    "show-welcome-banner": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "on"
+    },
+    "enable-antigravity": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "off"
+    },
+    "background-color": {
+      "state": "ENABLED",
+      "variants": {
+        "red": "#FF0000",
+        "blue": "#0000FF",
+        "green": "#00FF00",
+        "yellow": "#FFFF00"
+      },
+      "defaultVariant": "red"
+    },
+    "motd": {
+      "state": "ENABLED",
+      "variants": {
+        "welcome": "Welcome to the app!\nThis is a really long message to test line wrapping and all kinds of things like that.",
+        "maintenance": "This app is down for routine maintenance"
+      },
+      "defaultVariant": "welcome"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.26.24",
     "@headlessui/react": "^2.2.0",
+    "@openfeature/web-sdk": "^1.4.0",
     "@sentry/types": "^8.30.0",
     "@tanstack/react-query": "^5.56.2",
     "@tanstack/react-virtual": "^3.10.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@headlessui/react':
         specifier: ^2.2.0
         version: 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@openfeature/web-sdk':
+        specifier: ^1.4.0
+        version: 1.4.0(@openfeature/core@1.6.0)
       '@sentry/types':
         specifier: ^8.30.0
         version: 8.30.0
@@ -1667,6 +1670,14 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@openfeature/core@1.6.0':
+    resolution: {integrity: sha512-QYAtwdreZU9Mi/LXLRzXsUA7PhbtT7+UJfRBMIAy6MidZjMgIbNfoh6+MncXb3UocThn0OsYa8WLfWD9q43eCQ==}
+
+  '@openfeature/web-sdk@1.4.0':
+    resolution: {integrity: sha512-cMCt5jszLiZ9mLacS7XjMTEpbIS3asttSpyrPJ8rAdwDk86UjzfPwzMTSiccVolJqS299hWGXC1FGbu4IHX40Q==}
+    peerDependencies:
+      '@openfeature/core': ^1.6.0
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -8808,6 +8819,12 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
+
+  '@openfeature/core@1.6.0': {}
+
+  '@openfeature/web-sdk@1.4.0(@openfeature/core@1.6.0)':
+    dependencies:
+      '@openfeature/core': 1.6.0
 
   '@pkgjs/parseargs@0.11.0':
     optional: true

--- a/src/lib/adapters/OpenFeatureAdapter.ts
+++ b/src/lib/adapters/OpenFeatureAdapter.ts
@@ -1,0 +1,66 @@
+import {type Provider} from '@openfeature/web-sdk';
+import {getLocalStorage, clearLocalStorage, setLocalStorage} from 'toolbar/adapters/localStorage';
+import type {FeatureFlagAdapter, FlagMap, FlagValue} from 'toolbar/types/featureFlags';
+
+interface Opts {
+  provider: Provider;
+}
+
+export default function OpenFeatureAdapter(opts: Opts): FeatureFlagAdapter {
+  return {
+    getFlagMap(): FlagMap {
+      return flagsFromProvider(opts.provider);
+    },
+    getOverrides(): FlagMap {
+      return getLocalStorage();
+    },
+    setOverride(name: string, value: FlagValue) {
+      const prev = getLocalStorage();
+      const updated: FlagMap = {...prev, [name]: value};
+      setLocalStorage(updated);
+    },
+    clearOverrides: clearLocalStorage,
+    // TODO: implement `urlTemplate(name: string): string` depending on if we
+    // can detect the provider type.
+  };
+}
+
+function flagsFromProvider(provider: Provider): FlagMap {
+  if ('_flags' in provider) {
+    const flags = provider._flags as Record<FlagEntry[0], FlagEntry[1]>;
+    console.log('flagsFromProvider', flags);
+    return flagEntriesToFlags(Object.entries(flags));
+  }
+  if ('_flagCache' in provider) {
+    const flags = provider._flagCache as Record<FlagEntry[0], FlagEntry[1]>;
+    console.log('flagsFromProvider', flags);
+    return flagEntriesToFlags(Object.entries(flags));
+  }
+  return {};
+}
+
+function flagEntriesToFlags(entries: FlagEntry[]): FlagMap {
+  return entries.reduce((acc: FlagMap, entry: FlagEntry) => {
+    if (isBooleanValue(entry) || isStringValue(entry) || isNumberValue(entry)) {
+      acc[entry[0]] = entry[1].value;
+    }
+    return acc;
+  }, {});
+}
+
+type FlagEntry<T = unknown> = [string, {type?: unknown; value?: T}];
+
+function isBooleanValue(entry: FlagEntry): entry is FlagEntry<boolean> {
+  const [, meta] = entry;
+  return meta.type === 'boolValue' || typeof meta.value === 'boolean';
+}
+
+function isStringValue(entry: FlagEntry): entry is FlagEntry<string> {
+  const [, meta] = entry;
+  return meta.type === 'stringValue' || typeof meta.value === 'string';
+}
+
+function isNumberValue(entry: FlagEntry): entry is FlagEntry<number> {
+  const [, meta] = entry;
+  return meta.type === 'numberValue' || typeof meta.value === 'number';
+}

--- a/src/lib/adapters/localStorage.ts
+++ b/src/lib/adapters/localStorage.ts
@@ -1,0 +1,24 @@
+import type {FlagMap} from 'toolbar/types/featureFlags';
+import localStorage from 'toolbar/utils/localStorage';
+
+const LOCALSTORAGE_KEY = 'tlbr_flagOverrides';
+
+export function getLocalStorage(): FlagMap {
+  try {
+    return JSON.parse(localStorage.getItem(LOCALSTORAGE_KEY) ?? '{}');
+  } catch {
+    return {};
+  }
+}
+
+export function setLocalStorage(overrides: FlagMap) {
+  try {
+    localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(overrides));
+  } catch {
+    return;
+  }
+}
+
+export function clearLocalStorage() {
+  localStorage.setItem(LOCALSTORAGE_KEY, '{}');
+}

--- a/src/lib/components/panels/featureFlags/FeatureFlagItem.tsx
+++ b/src/lib/components/panels/featureFlags/FeatureFlagItem.tsx
@@ -13,11 +13,11 @@ export default function FeatureFlagItem({name}: Props) {
 
   const url = String(urlTemplate?.(name) ?? '');
   return (
-    <div className="flex flex-row justify-between gap-0.25 border-b border-b-translucentGray-200 py-1.5">
+    <div className="flex flex-row justify-between gap-1 border-b border-b-translucentGray-200 py-1.5">
       <div className="flex items-start">
         {url ? <ExternalLink to={{url}}>{name}</ExternalLink> : <span>{name}</span>}
       </div>
-      <div className="">
+      <div>
         <FlagValueInput name={name} value={flags[name]} override={overrides[name]} />
       </div>
     </div>

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,4 @@
+import OpenFeatureAdapter from 'toolbar/adapters/OpenFeatureAdapter';
 import mount from 'toolbar/mount';
 import type {InitConfig as iInitConfig} from 'toolbar/types/config';
 import hydrateConfig from 'toolbar/utils/hydrateConfig';
@@ -19,3 +20,5 @@ export function init(initConfig: InitConfig): Cleanup {
 export function getVersion() {
   return version;
 }
+
+export {OpenFeatureAdapter};

--- a/src/lib/utils/localStorage.ts
+++ b/src/lib/utils/localStorage.ts
@@ -24,10 +24,11 @@ const noopStorage: Storage = {
   },
 };
 
+const STORAGE_TEST_KEY = PREFIX + 'storage_check';
+
 // Returns a storage wrapper by trying to perform a single storage op.
 // This asserts that storage is both available and that it can be used.
 // See https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API
-const STORAGE_TEST_KEY = 'sentry';
 function createStorage(getStorage: () => Storage): Storage {
   try {
     const storage = getStorage();


### PR DESCRIPTION
In this PR i've added a makefile and config to be able to run https://flagd.dev/ doe dev purposes, in order to feed back into the the OpenFeature SDK and then through the adapter into the UI, and a new Adapter to consume those flags!

The OpenFeature adapter itself is kind of janky, there are no public methods in the OpenFeature SKD for getting 'all flag' info back out. The OpenFeature type interface is something like:
```
type Provider = {
  evaluateFlag(...): Result
};
class OpenFeature {
  constructor(provider: Provider)
  evaluateFlag(name, default) { return this.provider.evaluateFlag(...); }
}
```
And each provider implements their own 'private' cache of flag data, in different formats, in order to evaluate it. What's beneficial to us though it that most client side providers use the [Static-Context Paradigm](https://openfeature.dev/specification/glossary/#static-context-paradigm) to load data.

So this adapter is probably the most jank out of all because it's got this Provider abstraction and lots of private data. Some providers, like the [launchdarkly](https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/launchdarkly-client) one seem to defer to the standard launch darkly sdk. So we could target that independently, and have this OpenFeature share the implementation. 

Despite the challenges of implementing the OpenFeature adapter specifically, there are some benefits to getting something up. Doing this adapter brings in some code for reading/writing to localstorage, which will be shared across other adapters. Also there's also some `SentryToolbar.init()` api changes to account for loading order and async flag provider loading scenarios.

See Also:
- https://openfeature.dev/specification/sections/providers/#26-provider-context-reconciliation
- https://open-feature.github.io/js-sdk/interfaces/_openfeature_web_sdk.Client.html
- https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers
- https://flagd.dev/providers/web/