### PR TITLE
chore: Remove pre-commit script and let tests run in CI only

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,0 @@
-CI=true pnpm run test --passWithNoTests --silent


### PR DESCRIPTION
This was previously running tests locally before each commit which takes time and is noticeably slow.

So i'm removing this as all tests will be run in CI and must pass before merging.