### PR TITLE
fix: Set tooltip trigger cursor to `default`

### DIFF
--- a/src/lib/components/base/tooltip/Tooltip.tsx
+++ b/src/lib/components/base/tooltip/Tooltip.tsx
@@ -60,6 +60,7 @@ export const TooltipTrigger = forwardRef<HTMLElement, HTMLProps<HTMLElement> & {
     return (
       <button
         ref={ref}
+        className="cursor-default"
         // The user can style the trigger based on the state
         data-state={context.open ? 'open' : 'closed'}
         {...context.getReferenceProps(props)}>


### PR DESCRIPTION
Its a button because its focusable and keyboard accessible and stuff, but not clickable. So the cursor should reflect that.

Fixes #202