### PR TITLE
fix: replacing organizationSlug with projectIdOrSlug where its needed

### DIFF
--- a/src/lib/components/panels/feedback/FeedbackListItem.tsx
+++ b/src/lib/components/panels/feedback/FeedbackListItem.tsx
@@ -57,11 +57,11 @@ export default function FeedbackListItem({
 }
 
 function FeedbackType({item}: {item: FeedbackIssueListItem}) {
-  const {organizationSlug} = useContext(ConfigContext);
+  const {projectIdOrSlug} = useContext(ConfigContext);
 
   return (
     <span className={cx({truncate: true, 'font-bold': !item.hasSeen, 'text-sm': true})}>
-      <SentryAppLink to={{url: `/issues/${item.id}/`, query: {project: organizationSlug}}}>
+      <SentryAppLink to={{url: `/issues/${item.id}/`, query: {project: projectIdOrSlug}}}>
         {item.metadata.name ?? item.metadata.contact_email ?? 'Anonymous User'}
       </SentryAppLink>
     </span>

--- a/src/lib/components/panels/feedback/FeedbackPanel.tsx
+++ b/src/lib/components/panels/feedback/FeedbackPanel.tsx
@@ -34,7 +34,7 @@ export default function FeedbackPanel() {
       <h1 className="border-b border-b-translucentGray-200 px-2 py-1">
         <SentryAppLink
           className="flex flex-row items-center gap-1 font-medium"
-          to={{url: `/feedback/`, query: {project: organizationSlug}}}>
+          to={{url: `/feedback/`, query: {project: projectIdOrSlug}}}>
           <ProjectIcon size="sm" organizationSlug={organizationSlug} projectIdOrSlug={projectIdOrSlug} />
           Feedback
         </SentryAppLink>

--- a/src/lib/components/panels/issues/IssueListItem.tsx
+++ b/src/lib/components/panels/issues/IssueListItem.tsx
@@ -40,11 +40,11 @@ export default function IssueListItem({
 }
 
 function IssueType({item}: {item: Group}) {
-  const {organizationSlug} = useContext(ConfigContext);
+  const {projectIdOrSlug} = useContext(ConfigContext);
 
   return (
     <span className={cx({truncate: true, 'font-bold': !item.hasSeen, 'text-sm': true})}>
-      <SentryAppLink to={{url: `/issues/${item.id}/`, query: {project: organizationSlug}}}>
+      <SentryAppLink to={{url: `/issues/${item.id}/`, query: {project: projectIdOrSlug}}}>
         {item.metadata.type ?? '<unknown>'}
       </SentryAppLink>
     </span>

--- a/src/lib/components/panels/issues/IssuesPanel.tsx
+++ b/src/lib/components/panels/issues/IssuesPanel.tsx
@@ -36,7 +36,7 @@ export default function IssuesPanel() {
       <h1 className="border-b border-b-translucentGray-200 px-2 py-1">
         <SentryAppLink
           className="flex flex-row items-center gap-1 font-medium"
-          to={{url: `/issues/`, query: {project: organizationSlug}}}>
+          to={{url: `/issues/`, query: {project: projectIdOrSlug}}}>
           <ProjectIcon size="sm" organizationSlug={organizationSlug} projectIdOrSlug={projectIdOrSlug} />
           Issues
         </SentryAppLink>


### PR DESCRIPTION
Hey team!

I noticed that some of the links that include a `?project=` actually use the `organizationSlug` instead of the `projectIdOrSlug`. Don't know if it's intentional, but I opened this PR anyway. Feel free to decline if it's intentional.

I noticed this because when I clicked on the Issues panel title link to take me to that project's issues, the project filter wasn't applied and it showed me issues for all of my projects instead. I noticed that we're actually sending the org slug as a project.

One more thing - I also noticed if we're using the project slug (ex. `flashcards`) instead of the project ID (ex. `4506045517135872`) the filter is also not applied - it only works if we use the project ID. I'm assuming it's a change in the platform that fails to apply the filter, but I'll open a separate issue for that.

Let me know if I can further improve my PR.