### PR TITLE
feat(toolbar): Indicate when a FF override is in place

### DIFF
--- a/src/lib/components/Navigation.tsx
+++ b/src/lib/components/Navigation.tsx
@@ -4,6 +4,7 @@ import {useContext} from 'react';
 import type {MouseEvent} from 'react';
 import {NavLink, useLocation, useNavigate} from 'react-router-dom';
 import type {To} from 'react-router-dom';
+import Indicator from 'toolbar/components/base/Indicator';
 import {Menu, MenuItem} from 'toolbar/components/base/menu/Menu';
 import {Tooltip, TooltipTrigger, TooltipContent} from 'toolbar/components/base/tooltip/Tooltip';
 import IconFlag from 'toolbar/components/icon/IconFlag';
@@ -13,6 +14,7 @@ import IconMegaphone from 'toolbar/components/icon/IconMegaphone';
 import IconPin from 'toolbar/components/icon/IconPin';
 import IconSentry from 'toolbar/components/icon/IconSentry';
 import IconSettings from 'toolbar/components/icon/IconSettings';
+import {useFeatureFlagsContext} from 'toolbar/components/panels/featureFlags/featureFlagsContext';
 import {useApiProxyInstance} from 'toolbar/context/ApiProxyContext';
 import ConfigContext from 'toolbar/context/ConfigContext';
 import useNavigationExpansion from 'toolbar/hooks/useNavigationExpansion';
@@ -24,6 +26,7 @@ const navSeparator = cx(['m-0', 'w-full', 'border-translucentGray-200']);
 const menuSeparator = cx(['mx-1', 'my-0.5']);
 
 const navItemClassName = cx([
+  'relative',
   'flex',
   'flex-col',
   'rounded-md',
@@ -50,6 +53,8 @@ export default function Navigation() {
   const {pathname} = useLocation();
   const navigate = useNavigate();
   const apiProxy = useApiProxyInstance();
+
+  const {overrides} = useFeatureFlagsContext();
 
   const toPathOrHome = (to: To) => ({
     to,
@@ -123,6 +128,7 @@ export default function Navigation() {
           <Tooltip>
             <TooltipTrigger asChild>
               <NavLink {...toPathOrHome('/featureFlags')} className={navItemClassName}>
+                {Object.keys(overrides).length ? <Indicator position="top-right" variant="red" /> : null}
                 <IconFlag size="sm" />
               </NavLink>
             </TooltipTrigger>

--- a/src/lib/components/base/Indicator.tsx
+++ b/src/lib/components/base/Indicator.tsx
@@ -1,0 +1,18 @@
+import type {VariantProps} from 'cva';
+import {cva} from 'cva';
+
+const indicatorClass = cva(
+  'absolute box-content flex size-[0.55rem] items-center justify-center rounded-full border border-transparent leading-4',
+  {
+    variants: {
+      variant: {red: 'bg-red-400 text-gray-100'},
+      position: {
+        'top-right': 'right-0.25 top-0.25',
+      },
+    },
+  }
+);
+
+export default function Indicator(props: VariantProps<typeof indicatorClass>) {
+  return <div className={indicatorClass(props)} />;
+}

--- a/src/lib/components/panels/featureFlags/FeatureFlagAdapterStub.ts
+++ b/src/lib/components/panels/featureFlags/FeatureFlagAdapterStub.ts
@@ -1,0 +1,10 @@
+import type {FeatureFlagAdapter} from 'toolbar/types/featureFlags';
+
+const FeatureFlagAdapterStub: FeatureFlagAdapter = {
+  getFlagMap: () => ({}),
+  getOverrides: () => ({}),
+  setOverride: () => {},
+  clearOverrides: () => {},
+};
+
+export default FeatureFlagAdapterStub;

--- a/src/lib/components/panels/featureFlags/FeatureFlagFilters.tsx
+++ b/src/lib/components/panels/featureFlags/FeatureFlagFilters.tsx
@@ -1,3 +1,4 @@
+import Indicator from 'toolbar/components/base/Indicator';
 import Input from 'toolbar/components/base/Input';
 import SegmentedControl from 'toolbar/components/base/SegmentedControl';
 import {useFeatureFlagsContext} from 'toolbar/components/panels/featureFlags/featureFlagsContext';
@@ -8,18 +9,21 @@ interface Props {
 }
 
 export default function FeatureFlagFilters({defaultPrefilter}: Props) {
-  const {setPrefilter, setSearchTerm} = useFeatureFlagsContext();
+  const {overrides, setPrefilter, setSearchTerm} = useFeatureFlagsContext();
   return (
     <div className="grid grid-cols-2 gap-1">
       <Input className="col-span-1" onChange={e => setSearchTerm(e.target.value)} placeholder="Search" />
-      <SegmentedControl<Prefilter[]>
-        defaultSelected={defaultPrefilter}
-        options={{
-          all: {label: 'All'},
-          overrides: {label: 'Overrides'},
-        }}
-        onChange={value => setPrefilter(value)}
-      />
+      <div className="relative grid">
+        <SegmentedControl<Prefilter[]>
+          defaultSelected={defaultPrefilter}
+          options={{
+            all: {label: 'All'},
+            overrides: {label: 'Overrides'},
+          }}
+          onChange={value => setPrefilter(value)}
+        />
+        {Object.keys(overrides).length ? <Indicator position="top-right" variant="red" /> : null}
+      </div>
     </div>
   );
 }

--- a/src/lib/components/panels/featureFlags/FeatureFlagsPanel.tsx
+++ b/src/lib/components/panels/featureFlags/FeatureFlagsPanel.tsx
@@ -5,10 +5,7 @@ import IconChevron from 'toolbar/components/icon/IconChevron';
 import IconSettings from 'toolbar/components/icon/IconSettings';
 import CustomOverride from 'toolbar/components/panels/featureFlags/CustomOverride';
 import FeatureFlagFilters from 'toolbar/components/panels/featureFlags/FeatureFlagFilters';
-import {
-  FeatureFlagsContextProvider,
-  useFeatureFlagsContext,
-} from 'toolbar/components/panels/featureFlags/featureFlagsContext';
+import {useFeatureFlagsContext} from 'toolbar/components/panels/featureFlags/featureFlagsContext';
 import FeatureFlagTable from 'toolbar/components/panels/featureFlags/FeatureFlagTable';
 import ConfigContext from 'toolbar/context/ConfigContext';
 
@@ -20,15 +17,7 @@ const sectionBorder = cx('border-b border-b-translucentGray-200');
 export default function FeatureFlagsPanel() {
   const {featureFlags} = useContext(ConfigContext);
 
-  if (featureFlags) {
-    return (
-      <FeatureFlagsContextProvider featureFlags={featureFlags}>
-        <FeatureFlagEditor />
-      </FeatureFlagsContextProvider>
-    );
-  } else {
-    return <FeatureFlagConfigHelp />;
-  }
+  return featureFlags ? <FeatureFlagEditor /> : <FeatureFlagConfigHelp />;
 }
 
 function FeatureFlagConfigHelp() {
@@ -85,7 +74,14 @@ function FeatureFlagEditor() {
       ) : null}
 
       {isDirty ? (
-        <div className={cx(sectionBorder, sectionPadding, 'text-sm text-gray-300')}>Reload to see changes</div>
+        <a
+          href="#"
+          onClick={() => {
+            window.location.reload();
+          }}
+          className={cx(sectionBorder, sectionPadding, 'text-sm text-gray-300 hover:underline')}>
+          Reload to see changes
+        </a>
       ) : null}
 
       <div className={cx(sectionPadding, 'flex flex-col gap-1 text-sm')}>

--- a/src/lib/components/panels/featureFlags/featureFlagsContext.tsx
+++ b/src/lib/components/panels/featureFlags/featureFlagsContext.tsx
@@ -1,5 +1,6 @@
 import type {Dispatch, ReactNode, SetStateAction} from 'react';
 import {createContext, useCallback, useContext, useEffect, useState} from 'react';
+import FeatureFlagAdapterStub from 'toolbar/components/panels/featureFlags/FeatureFlagAdapterStub';
 import type {Prefilter} from 'toolbar/components/panels/featureFlags/FeatureFlagsPanel';
 import type {FeatureFlagAdapter, FlagMap, FlagValue} from 'toolbar/types/featureFlags';
 
@@ -87,10 +88,10 @@ const FeatureFlagContext = createContext<Context>({
 
 interface Props {
   children: ReactNode;
-  featureFlags: FeatureFlagAdapter;
+  featureFlags: undefined | FeatureFlagAdapter;
 }
 
-export function FeatureFlagsContextProvider({children, featureFlags}: Props) {
+export function FeatureFlagsContextProvider({children, featureFlags = FeatureFlagAdapterStub}: Props) {
   const [flags, setFlags] = useState<FlagMap>({});
   const flagsPromise = Promise.resolve(featureFlags.getFlagMap());
   useEffect(() => {

--- a/src/lib/context/Providers.tsx
+++ b/src/lib/context/Providers.tsx
@@ -1,6 +1,7 @@
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {useMemo, type ReactNode} from 'react';
 import {MemoryRouter} from 'react-router-dom';
+import {FeatureFlagsContextProvider} from 'toolbar/components/panels/featureFlags/featureFlagsContext';
 import {ApiProxyContextProvider} from 'toolbar/context/ApiProxyContext';
 import ConfigContext from 'toolbar/context/ConfigContext';
 import PortalTargetContext from 'toolbar/context/PortalTargetContext';
@@ -18,7 +19,9 @@ export default function Providers({children, config, portalMount}: Props) {
       <PortalTargetContext.Provider value={portalMount}>
         <ApiProxyContextProvider>
           <QueryProvider>
-            <MemoryRouter future={{}}>{children}</MemoryRouter>
+            <MemoryRouter future={{}}>
+              <FeatureFlagsContextProvider featureFlags={config.featureFlags}>{children}</FeatureFlagsContextProvider>
+            </MemoryRouter>
           </QueryProvider>
         </ApiProxyContextProvider>
       </PortalTargetContext.Provider>


### PR DESCRIPTION
Little indicators in the Nav and ontop of the segmented control to view overrides only:

<img width="404" alt="SCR-20250314-njae" src="https://github.com/user-attachments/assets/0d2a3a24-776f-418b-8d00-3e949c6269ee" />

Fixes https://github.com/getsentry/sentry/issues/86991