### PR TITLE
fix: Support Sveltekit optional params in transaction names

### DIFF
--- a/src/lib/utils/transactionToSearchTerm.spec.ts
+++ b/src/lib/utils/transactionToSearchTerm.spec.ts
@@ -7,6 +7,7 @@ describe('transactionToSearchTerm', () => {
       searchTerm: '/alerts/rules/details/*/',
     },
     {transactionName: '/pokemon/[pokemonName]', searchTerm: '/pokemon/*'},
+    {transactionName: '/pokemon/[[pokemonName]]', searchTerm: '/pokemon/*'},
     {transactionName: '/replays/<id>/details/', searchTerm: '/replays/*/details/'},
     {
       transactionName: '/param/{id}/param2/key:value/',

--- a/src/lib/utils/transactionToSearchTerm.ts
+++ b/src/lib/utils/transactionToSearchTerm.ts
@@ -1,8 +1,9 @@
 // (:[^/:]+) matches `:param` used by React, Vue, Angular, Express, Ruby on Rails, Phoenix, Solid
 // (\[[^/\]]+\]) matches `[param]` used by Next.js, Nuxt.js, Svelte
+// (\[\[[^/\]]+\]\]) matches `[[param]]` used by SvelteKit
 // ({[^/}]+}) matches `{param}` used by ASP.NET Core, Laravel, Symfony
 // (<[^>/]+>) matches `<param>` used by Flask, Django
-const PARAMETERIZED_REGEX = /^((:[^/:]+)|(\[[^/\]]+\])|({[^/}]+})|(<[^>/]+>))$/;
+const PARAMETERIZED_REGEX = /^((:[^/:]+)|(\[[^/\]]+\])|(\[\[[^/\]]+\]\])|({[^/}]+})|(<[^>/]+>))$/;
 
 // Transaction name could contain the resolved URL instead of the route pattern
 // (ie: actual `id` instead of `:id`) so we match any param that is a number.


### PR DESCRIPTION
https://svelte.dev/docs/kit/advanced-routing\#Matching

sveltekit routes can use matches like these:
```
src/routes/[...catchall]/+page.svelte
src/routes/[[a=x]]/+page.svelte
src/routes/[b]/+page.svelte
src/routes/foo-[c]/+page.svelte
src/routes/foo-abc/+page.svelte
```

We support all except `src/routes/foo-[c]/` now.