### PR TITLE
ref: Create static & mutable Config providers so some values can be overridden in memory

### DIFF
--- a/src/lib/components/AppRouter.tsx
+++ b/src/lib/components/AppRouter.tsx
@@ -1,4 +1,3 @@
-import {useContext} from 'react';
 import {Fragment} from 'react/jsx-runtime';
 import {Routes, Route, Outlet} from 'react-router-dom';
 import DebugState from 'toolbar/components/DebugState';
@@ -14,7 +13,7 @@ import Disconnected from 'toolbar/components/unauth/Disconnected';
 import InvalidDomain from 'toolbar/components/unauth/InvalidDomain';
 import Login from 'toolbar/components/unauth/Login';
 import MissingProject from 'toolbar/components/unauth/MissingProject';
-import ConfigContext from 'toolbar/context/ConfigContext';
+import {useConfigContext} from 'toolbar/context/ConfigContext';
 import useClearQueryCacheOnProxyStateChange from 'toolbar/hooks/useClearQueryCacheOnProxyStateChange';
 import useNavigateOnProxyStateChange from 'toolbar/hooks/useNavigateOnProxyStateChange';
 
@@ -22,7 +21,7 @@ export default function AppRouter() {
   useNavigateOnProxyStateChange();
   useClearQueryCacheOnProxyStateChange();
 
-  const {placement} = useContext(ConfigContext);
+  const [{placement}] = useConfigContext();
   return (
     <Routes>
       <Route

--- a/src/lib/components/DebugState.tsx
+++ b/src/lib/components/DebugState.tsx
@@ -1,12 +1,11 @@
-import {useContext} from 'react';
 import {useLocation} from 'react-router-dom';
 import {useApiProxyState} from 'toolbar/context/ApiProxyContext';
-import ConfigContext from 'toolbar/context/ConfigContext';
+import {useConfigContext} from 'toolbar/context/ConfigContext';
 import {DebugTarget} from 'toolbar/types/Configuration';
 
 export default function DebugState() {
   const proxyState = useApiProxyState();
-  const {debug} = useContext(ConfigContext);
+  const [{debug}] = useConfigContext();
 
   const location = useLocation();
   return (

--- a/src/lib/components/Navigation.tsx
+++ b/src/lib/components/Navigation.tsx
@@ -1,6 +1,6 @@
 import {Transition} from '@headlessui/react';
 import {cx} from 'cva';
-import {Fragment, useContext} from 'react';
+import {Fragment} from 'react';
 import type {MouseEvent} from 'react';
 import {NavLink, useLocation, useNavigate} from 'react-router-dom';
 import type {To} from 'react-router-dom';
@@ -17,7 +17,7 @@ import IconMegaphone from 'toolbar/components/icon/IconMegaphone';
 import IconSentry from 'toolbar/components/icon/IconSentry';
 import IconSettings from 'toolbar/components/icon/IconSettings';
 import {useApiProxyInstance} from 'toolbar/context/ApiProxyContext';
-import ConfigContext from 'toolbar/context/ConfigContext';
+import {useConfigContext} from 'toolbar/context/ConfigContext';
 import {useFeatureFlagAdapterContext} from 'toolbar/context/FeatureFlagAdapterContext';
 import {useHiddenAppContext} from 'toolbar/context/HiddenAppContext';
 import useNavigationExpansion from 'toolbar/hooks/useNavigationExpansion';
@@ -51,7 +51,7 @@ const navItemClassName = cx([
 const menuItemClass = cx('flex grow gap-1 whitespace-nowrap');
 
 export default function Navigation() {
-  const {debug} = useContext(ConfigContext);
+  const [{debug}] = useConfigContext();
   const {isExpanded, isPinned, setIsHovered, setIsPinned} = useNavigationExpansion();
   const {pathname} = useLocation();
   const navigate = useNavigate();

--- a/src/lib/components/SentryAppLink.tsx
+++ b/src/lib/components/SentryAppLink.tsx
@@ -1,8 +1,8 @@
 import {type UrlObject} from 'query-string';
 import type {ForwardedRef} from 'react';
-import {forwardRef, useContext, type MouseEvent} from 'react';
+import {forwardRef, type MouseEvent} from 'react';
 import ExternalLink from 'toolbar/components/base/ExternalLink';
-import ConfigContext from 'toolbar/context/ConfigContext';
+import {useConfigContext} from 'toolbar/context/ConfigContext';
 import {getSentryWebOrigin} from 'toolbar/sentryApi/urls';
 
 export interface Props {
@@ -16,7 +16,7 @@ const SentryAppLink = forwardRef(function SentryAppLink(
   {children, className, to, onClick}: Props,
   ref: ForwardedRef<HTMLAnchorElement>
 ) {
-  const config = useContext(ConfigContext);
+  const [config] = useConfigContext();
 
   return (
     <ExternalLink

--- a/src/lib/components/panels/featureFlags/FeatureFlagsPanel.tsx
+++ b/src/lib/components/panels/featureFlags/FeatureFlagsPanel.tsx
@@ -1,5 +1,5 @@
 import {cx} from 'cva';
-import {useContext, useMemo, useState} from 'react';
+import {useMemo, useState} from 'react';
 import ExternalLink from 'toolbar/components/base/ExternalLink';
 import IconChevron from 'toolbar/components/icon/IconChevron';
 import IconClose from 'toolbar/components/icon/IconClose';
@@ -8,7 +8,7 @@ import InfiniteListItems from 'toolbar/components/InfiniteListItems';
 import CustomOverride from 'toolbar/components/panels/featureFlags/CustomOverride';
 import FeatureFlagFilters from 'toolbar/components/panels/featureFlags/FeatureFlagFilters';
 import FeatureFlagItem from 'toolbar/components/panels/featureFlags/FeatureFlagItem';
-import ConfigContext from 'toolbar/context/ConfigContext';
+import {useConfigContext} from 'toolbar/context/ConfigContext';
 import {useFeatureFlagAdapterContext} from 'toolbar/context/FeatureFlagAdapterContext';
 import type {ApiResult} from 'toolbar/types/api';
 
@@ -18,7 +18,7 @@ const sectionPadding = cx('px-2 py-1');
 const sectionBorder = cx('border-b border-b-translucentGray-200');
 
 export default function FeatureFlagsPanel() {
-  const {featureFlags} = useContext(ConfigContext);
+  const [{featureFlags}] = useConfigContext();
 
   return featureFlags ? <FeatureFlagEditor /> : <FeatureFlagConfigHelp />;
 }

--- a/src/lib/components/panels/feedback/FeedbackListItem.tsx
+++ b/src/lib/components/panels/feedback/FeedbackListItem.tsx
@@ -1,6 +1,6 @@
 import {cx} from 'cva';
 import type {ReactElement} from 'react';
-import {useContext, useMemo} from 'react';
+import {useMemo} from 'react';
 import AssignedTo from 'toolbar/components/AssignedTo';
 import {Tooltip, TooltipTrigger, TooltipContent} from 'toolbar/components/base/tooltip/Tooltip';
 import RelativeDateTime from 'toolbar/components/datetime/RelativeDateTime';
@@ -10,7 +10,7 @@ import IconImage from 'toolbar/components/icon/IconImage';
 import IconPlay from 'toolbar/components/icon/IconPlay';
 import ProjectIcon from 'toolbar/components/project/ProjectIcon';
 import SentryAppLink from 'toolbar/components/SentryAppLink';
-import ConfigContext from 'toolbar/context/ConfigContext';
+import {useConfigContext} from 'toolbar/context/ConfigContext';
 import useReplayCount from 'toolbar/hooks/useReplayCount';
 import type {FeedbackIssueListItem} from 'toolbar/sentryApi/types/group';
 import type Member from 'toolbar/sentryApi/types/Member';
@@ -27,7 +27,7 @@ export default function FeedbackListItem({
   teams: OrganizationTeam[] | undefined;
   members: Member[] | undefined;
 }) {
-  const {organizationSlug} = useContext(ConfigContext);
+  const [{organizationSlug}] = useConfigContext();
   const {feedbackHasReplay} = useReplayCountForFeedbacks(organizationSlug);
   const hasReplayId = feedbackHasReplay(item.id);
   const isFatal = FATAL_SOURCES.includes(item.metadata.source ?? '');
@@ -59,7 +59,7 @@ export default function FeedbackListItem({
 }
 
 function FeedbackType({item}: {item: FeedbackIssueListItem}) {
-  const {projectIdOrSlug} = useContext(ConfigContext);
+  const [{projectIdOrSlug}] = useConfigContext();
 
   return (
     <span className={cx({truncate: true, 'font-bold': !item.hasSeen, 'text-sm': true})}>
@@ -83,7 +83,7 @@ function FeedbackMessage({message}: {message: string | null | undefined}) {
 }
 
 function FeedbackProject({item}: {item: FeedbackIssueListItem}) {
-  const {organizationSlug, projectIdOrSlug} = useContext(ConfigContext);
+  const [{organizationSlug, projectIdOrSlug}] = useConfigContext();
 
   return (
     <div className="flex flex-row items-center gap-0.5">

--- a/src/lib/components/panels/feedback/FeedbackPanel.tsx
+++ b/src/lib/components/panels/feedback/FeedbackPanel.tsx
@@ -1,4 +1,3 @@
-import {useContext} from 'react';
 import {Tooltip, TooltipContent, TooltipTrigger} from 'toolbar/components/base/tooltip/Tooltip';
 import InfiniteListItems from 'toolbar/components/InfiniteListItems';
 import InfiniteListState from 'toolbar/components/InfiniteListState';
@@ -7,14 +6,14 @@ import useInfiniteFeedbackList from 'toolbar/components/panels/feedback/useInfin
 import Placeholder from 'toolbar/components/Placeholder';
 import ProjectIcon from 'toolbar/components/project/ProjectIcon';
 import SentryAppLink from 'toolbar/components/SentryAppLink';
-import ConfigContext from 'toolbar/context/ConfigContext';
+import {useConfigContext} from 'toolbar/context/ConfigContext';
 import useFetchSentryData from 'toolbar/hooks/fetch/useFetchSentryData';
 import useCurrentSentryTransactionName from 'toolbar/hooks/useCurrentSentryTransactionName';
 import {useMembersQuery, useTeamsQuery} from 'toolbar/sentryApi/queryKeys';
 import type {FeedbackIssueListItem} from 'toolbar/sentryApi/types/group';
 
 export default function FeedbackPanel() {
-  const {organizationSlug, projectIdOrSlug} = useContext(ConfigContext);
+  const [{organizationSlug, projectIdOrSlug}] = useConfigContext();
 
   const transactionName = useCurrentSentryTransactionName();
   const query = transactionName ? `url:*${transactionName}` : '';

--- a/src/lib/components/panels/feedback/useInfiniteFeedbackList.ts
+++ b/src/lib/components/panels/feedback/useInfiniteFeedbackList.ts
@@ -1,5 +1,4 @@
-import {useContext} from 'react';
-import ConfigContext from 'toolbar/context/ConfigContext';
+import {useConfigContext} from 'toolbar/context/ConfigContext';
 import useFetchInfiniteSentryData from 'toolbar/hooks/fetch/useFetchInfiniteSentryData';
 import useFetchSentryData from 'toolbar/hooks/fetch/useFetchSentryData';
 import {useInfiniteFeedbackListQuery, useProjectQuery} from 'toolbar/sentryApi/queryKeys';
@@ -9,7 +8,7 @@ interface Props {
 }
 
 export default function useInfiniteFeedbackList({query}: Props) {
-  const {environment, organizationSlug, projectIdOrSlug} = useContext(ConfigContext);
+  const [{environment, organizationSlug, projectIdOrSlug}] = useConfigContext();
 
   const {data: project, isSuccess} = useFetchSentryData({
     ...useProjectQuery(String(organizationSlug), String(projectIdOrSlug)),

--- a/src/lib/components/panels/issues/IssueListItem.tsx
+++ b/src/lib/components/panels/issues/IssueListItem.tsx
@@ -1,10 +1,9 @@
 import {cx} from 'cva';
-import {useContext} from 'react';
 import AssignedTo from 'toolbar/components/AssignedTo';
 import RelativeDateTime from 'toolbar/components/datetime/RelativeDateTime';
 import ProjectIcon from 'toolbar/components/project/ProjectIcon';
 import SentryAppLink from 'toolbar/components/SentryAppLink';
-import ConfigContext from 'toolbar/context/ConfigContext';
+import {useConfigContext} from 'toolbar/context/ConfigContext';
 import type {Group} from 'toolbar/sentryApi/types/group';
 import type Member from 'toolbar/sentryApi/types/Member';
 import type {OrganizationTeam} from 'toolbar/sentryApi/types/Organization';
@@ -40,7 +39,7 @@ export default function IssueListItem({
 }
 
 function IssueType({item}: {item: Group}) {
-  const {projectIdOrSlug} = useContext(ConfigContext);
+  const [{projectIdOrSlug}] = useConfigContext();
 
   return (
     <span className={cx({truncate: true, 'font-bold': !item.hasSeen, 'text-sm': true})}>
@@ -66,7 +65,7 @@ function IssueMessage({message}: {message: string | null | undefined}) {
 }
 
 function IssueProject({item}: {item: Group}) {
-  const {organizationSlug, projectIdOrSlug} = useContext(ConfigContext);
+  const [{organizationSlug, projectIdOrSlug}] = useConfigContext();
 
   return (
     <div className="flex flex-row items-center gap-0.5">

--- a/src/lib/components/panels/issues/IssuesPanel.tsx
+++ b/src/lib/components/panels/issues/IssuesPanel.tsx
@@ -1,4 +1,3 @@
-import {useContext} from 'react';
 import {Tooltip, TooltipContent, TooltipTrigger} from 'toolbar/components/base/tooltip/Tooltip';
 import InfiniteListItems from 'toolbar/components/InfiniteListItems';
 import InfiniteListState from 'toolbar/components/InfiniteListState';
@@ -7,14 +6,14 @@ import useInfiniteIssuesList from 'toolbar/components/panels/issues/useInfiniteI
 import Placeholder from 'toolbar/components/Placeholder';
 import ProjectIcon from 'toolbar/components/project/ProjectIcon';
 import SentryAppLink from 'toolbar/components/SentryAppLink';
-import ConfigContext from 'toolbar/context/ConfigContext';
+import {useConfigContext} from 'toolbar/context/ConfigContext';
 import useFetchSentryData from 'toolbar/hooks/fetch/useFetchSentryData';
 import useCurrentSentryTransactionName from 'toolbar/hooks/useCurrentSentryTransactionName';
 import {useMembersQuery, useTeamsQuery} from 'toolbar/sentryApi/queryKeys';
 import {IssueCategory, type Group} from 'toolbar/sentryApi/types/group';
 
 export default function IssuesPanel() {
-  const {organizationSlug, projectIdOrSlug} = useContext(ConfigContext);
+  const [{organizationSlug, projectIdOrSlug}] = useConfigContext();
 
   const transactionName = useCurrentSentryTransactionName();
   const query = transactionName

--- a/src/lib/components/panels/issues/useInfiniteIssuesList.ts
+++ b/src/lib/components/panels/issues/useInfiniteIssuesList.ts
@@ -1,5 +1,4 @@
-import {useContext} from 'react';
-import ConfigContext from 'toolbar/context/ConfigContext';
+import {useConfigContext} from 'toolbar/context/ConfigContext';
 import useFetchInfiniteSentryData from 'toolbar/hooks/fetch/useFetchInfiniteSentryData';
 import useFetchSentryData from 'toolbar/hooks/fetch/useFetchSentryData';
 import {useInfiniteIssueListQuery, useProjectQuery} from 'toolbar/sentryApi/queryKeys';
@@ -9,7 +8,7 @@ interface Props {
 }
 
 export default function useInfiniteIssuesList({query}: Props) {
-  const {environment, organizationSlug, projectIdOrSlug} = useContext(ConfigContext);
+  const [{environment, organizationSlug, projectIdOrSlug}] = useConfigContext();
 
   const {data: project, isSuccess} = useFetchSentryData({
     ...useProjectQuery(String(organizationSlug), String(projectIdOrSlug)),

--- a/src/lib/components/panels/settings/SettingsPanel.tsx
+++ b/src/lib/components/panels/settings/SettingsPanel.tsx
@@ -1,8 +1,7 @@
-import {useContext} from 'react';
-import ConfigContext from 'toolbar/context/ConfigContext';
+import {useConfigContext} from 'toolbar/context/ConfigContext';
 
 export default function SettingsPanel() {
-  const config = useContext(ConfigContext);
+  const [config] = useConfigContext();
 
   return (
     <section className="h-full overflow-y-auto">

--- a/src/lib/components/unauth/Connecting.tsx
+++ b/src/lib/components/unauth/Connecting.tsx
@@ -1,9 +1,9 @@
-import {useContext, useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import UnauthPill from 'toolbar/components/unauth/UnauthPill';
-import ConfigContext from 'toolbar/context/ConfigContext';
+import {useConfigContext} from 'toolbar/context/ConfigContext';
 
 export default function Connecting() {
-  const {sentryOrigin} = useContext(ConfigContext);
+  const [{sentryOrigin}] = useConfigContext();
 
   const [visible, setVisible] = useState(false);
   useEffect(() => {

--- a/src/lib/components/unauth/Disconnected.tsx
+++ b/src/lib/components/unauth/Disconnected.tsx
@@ -1,9 +1,8 @@
-import {useContext} from 'react';
 import UnauthPill from 'toolbar/components/unauth/UnauthPill';
-import ConfigContext from 'toolbar/context/ConfigContext';
+import {useConfigContext} from 'toolbar/context/ConfigContext';
 
 export default function Disconnected() {
-  const {sentryOrigin} = useContext(ConfigContext);
+  const [{sentryOrigin}] = useConfigContext();
 
   return (
     <UnauthPill>

--- a/src/lib/components/unauth/InvalidDomain.tsx
+++ b/src/lib/components/unauth/InvalidDomain.tsx
@@ -1,10 +1,8 @@
-import {useContext} from 'react';
 import UnauthPill, {UnauthPillAppLink} from 'toolbar/components/unauth/UnauthPill';
-import ConfigContext from 'toolbar/context/ConfigContext';
+import {useConfigContext} from 'toolbar/context/ConfigContext';
 
 export default function InvalidDomain() {
-  const config = useContext(ConfigContext);
-  const {projectIdOrSlug} = config;
+  const [{projectIdOrSlug}] = useConfigContext();
 
   return (
     <UnauthPill>

--- a/src/lib/components/unauth/Login.tsx
+++ b/src/lib/components/unauth/Login.tsx
@@ -1,14 +1,14 @@
-import {useCallback, useContext, useRef, useState} from 'react';
+import {useCallback, useRef, useState} from 'react';
 import UnauthPill from 'toolbar/components/unauth/UnauthPill';
 import {UnauthPillButton} from 'toolbar/components/unauth/UnauthPill';
 import {useApiProxyInstance} from 'toolbar/context/ApiProxyContext';
-import ConfigContext from 'toolbar/context/ConfigContext';
+import {useConfigContext} from 'toolbar/context/ConfigContext';
 import {DebugTarget} from 'toolbar/types/Configuration';
 
 const POPUP_MESSAGE_DELAY_MS = 3_000;
 
 export default function Login() {
-  const {debug} = useContext(ConfigContext);
+  const [{debug}] = useConfigContext();
   const debugLoginSuccess = debug.includes(DebugTarget.LOGIN_SUCCESS);
 
   const apiProxy = useApiProxyInstance();

--- a/src/lib/components/unauth/MissingProject.tsx
+++ b/src/lib/components/unauth/MissingProject.tsx
@@ -1,9 +1,8 @@
-import {useContext} from 'react';
 import UnauthPill, {UnauthPillAppLink} from 'toolbar/components/unauth/UnauthPill';
-import ConfigContext from 'toolbar/context/ConfigContext';
+import {useConfigContext} from 'toolbar/context/ConfigContext';
 
 export default function MissingProject() {
-  const {projectIdOrSlug} = useContext(ConfigContext);
+  const [{projectIdOrSlug}] = useConfigContext();
 
   return (
     <UnauthPill>

--- a/src/lib/context/ApiProxyContext.tsx
+++ b/src/lib/context/ApiProxyContext.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-refresh/only-export-components */
 import {createContext, useCallback, useContext, useEffect, useRef, useState} from 'react';
 import type {ReactNode} from 'react';
-import ConfigContext from 'toolbar/context/ConfigContext';
+import {useConfigContext} from 'toolbar/context/ConfigContext';
 import defaultConfig from 'toolbar/context/defaultConfig';
 import usePrevious from 'toolbar/hooks/usePrevious';
 import {getSentryIFrameOrigin} from 'toolbar/sentryApi/urls';
@@ -16,7 +16,7 @@ interface Props {
 }
 
 export function ApiProxyContextProvider({children}: Props) {
-  const config = useContext(ConfigContext);
+  const [config] = useConfigContext();
   const {debug, organizationSlug, projectIdOrSlug} = config;
   const enableLogging = debug.includes(DebugTarget.LOGGING);
 

--- a/src/lib/context/ConfigContext.tsx
+++ b/src/lib/context/ConfigContext.tsx
@@ -1,7 +1,37 @@
-import {createContext} from 'react';
+import type {Dispatch, ReactNode, SetStateAction} from 'react';
+import {createContext, useContext, useState} from 'react';
 import defaultConfig from 'toolbar/context/defaultConfig';
 import type {Configuration} from 'toolbar/types/Configuration';
 
-const ConfigContext = createContext<Configuration>(defaultConfig);
+const ConfigContext = createContext<[Configuration, Dispatch<SetStateAction<Configuration>>]>([
+  defaultConfig,
+  () => {},
+]);
 
-export default ConfigContext;
+/*
+ * The root config cannot be overridden. Doing that would cause important
+ * providers to be re-mounted like the ApiProxyContextProvider.
+ */
+export function StaticConfigProvider({children, config}: {children: ReactNode; config: Configuration}) {
+  return <ConfigContext.Provider value={[config, () => {}]}>{children}</ConfigContext.Provider>;
+}
+
+/*
+ * This provider will allow you to override any config value, but it might not
+ * do anything if the config is used by root providers.
+ *
+ * Nesting these is not a supported use case.
+ */
+export function MutableConfigProvider({children}: {children: ReactNode}) {
+  const [config] = useConfigContext();
+  const state = useState<Configuration>(config);
+
+  return <ConfigContext.Provider value={state}>{children}</ConfigContext.Provider>;
+}
+
+/**
+ * Read the Configuration from the nearest `MutableConfigProvider` or `StaticConfigProvider`.
+ */
+export function useConfigContext() {
+  return useContext(ConfigContext);
+}

--- a/src/lib/context/FeatureFlagAdapterContext.tsx
+++ b/src/lib/context/FeatureFlagAdapterContext.tsx
@@ -1,6 +1,6 @@
 import type {ReactNode} from 'react';
 import {createContext, useContext, useEffect, useState} from 'react';
-import ConfigContext from 'toolbar/context/ConfigContext';
+import {useConfigContext} from 'toolbar/context/ConfigContext';
 import type {FlagMap, FlagValue} from 'toolbar/init/featureFlagAdapter';
 
 interface State {
@@ -22,7 +22,7 @@ const FeatureFlagAdapterContext = createContext<State>({
 });
 
 export function FeatureFlagAdapterProvider({children}: {children: ReactNode}) {
-  const {featureFlags} = useContext(ConfigContext);
+  const [{featureFlags}] = useConfigContext();
   const [state, setState] = useState(() => ({
     isDirty: false,
     flagMap: {},

--- a/src/lib/context/Providers.tsx
+++ b/src/lib/context/Providers.tsx
@@ -2,7 +2,7 @@ import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {useMemo, type ReactNode} from 'react';
 import {MemoryRouter} from 'react-router-dom';
 import {ApiProxyContextProvider} from 'toolbar/context/ApiProxyContext';
-import ConfigContext from 'toolbar/context/ConfigContext';
+import {StaticConfigProvider, MutableConfigProvider} from 'toolbar/context/ConfigContext';
 import {FeatureFlagAdapterProvider} from 'toolbar/context/FeatureFlagAdapterContext';
 import {HiddenAppProvider} from 'toolbar/context/HiddenAppContext';
 import PortalTargetContext from 'toolbar/context/PortalTargetContext';
@@ -16,19 +16,21 @@ interface Props {
 
 export default function Providers({children, config, portalMount}: Props) {
   return (
-    <ConfigContext.Provider value={config}>
+    <StaticConfigProvider config={config}>
       <HiddenAppProvider>
         <PortalTargetContext.Provider value={portalMount}>
           <ApiProxyContextProvider>
             <QueryProvider>
               <MemoryRouter future={{}}>
-                <FeatureFlagAdapterProvider>{children}</FeatureFlagAdapterProvider>
+                <FeatureFlagAdapterProvider>
+                  <MutableConfigProvider>{children}</MutableConfigProvider>
+                </FeatureFlagAdapterProvider>
               </MemoryRouter>
             </QueryProvider>
           </ApiProxyContextProvider>
         </PortalTargetContext.Provider>
       </HiddenAppProvider>
-    </ConfigContext.Provider>
+    </StaticConfigProvider>
   );
 }
 

--- a/src/lib/hooks/useCurrentSentryTransactionName.ts
+++ b/src/lib/hooks/useCurrentSentryTransactionName.ts
@@ -1,10 +1,10 @@
 import type {StartSpanOptions} from '@sentry/types';
-import {useState, useEffect, useContext} from 'react';
-import ConfigContext from 'toolbar/context/ConfigContext';
+import {useState, useEffect} from 'react';
+import {useConfigContext} from 'toolbar/context/ConfigContext';
 import useSentryClientAndScope from 'toolbar/hooks/useSentryClientAndScope';
 
 export default function useCurrentSentryTransactionName() {
-  const {transactionToSearchTerm} = useContext(ConfigContext);
+  const [{transactionToSearchTerm}] = useConfigContext();
   const {scope, client} = useSentryClientAndScope();
 
   const [transactionName, setTransactionName] = useState(scope?.getScopeData().transactionName ?? '');


### PR DESCRIPTION
We want to be able to override stuff like `placement`, but some things like `sentryOrigin` cannot be overridden because that would cause the whole `<ApiProxyContextProvider>` to re-connect and be a weird experience. 

So we have the `<StaticConfigProvider>` which wraps the whole app and nothing inside it can be changed. 
Then down below we have `<MutableConfigProvider>` where the fields can be changed. If something below here depends on a field then it will be updated to use the new value. This means that fields like `placement` can be updated without any problems, other fields like `debug` and `sentryOrigin` can be updated, but nothing lower really uses them. This is a limitation that maybe we can address in a followup iteration. 

It's important is not to re-render `<ApiProxyContextProvider>` and friends, because it's slow and will destroy the login context for no good reason.
