### PR TITLE
fix: CenterLayout.MainArea should not capture mouse events, 

### DIFF
--- a/src/lib/components/layouts/CenterLayout.tsx
+++ b/src/lib/components/layouts/CenterLayout.tsx
@@ -12,7 +12,7 @@ export default function CenterLayout({children}: Props) {
 
 CenterLayout.MainArea = function MainArea({children}: Props) {
   return (
-    <div role="dialog" className="pointer-events-auto flex overscroll-contain contain-layout">
+    <div role="dialog" className="flex overscroll-contain contain-layout">
       {children}
     </div>
   );

--- a/src/lib/components/unauth/UnauthPill.tsx
+++ b/src/lib/components/unauth/UnauthPill.tsx
@@ -28,7 +28,7 @@ export default function UnauthPill({children}: Props) {
   const [, setIsHidden] = useHiddenAppContext();
 
   return (
-    <div className="flex translate-y-[30vh] flex-row place-items-center gap-1 rounded-full bg-black-raw p-px px-2 text-sm text-white-raw">
+    <div className="pointer-events-auto flex translate-y-[30vh] flex-row place-items-center gap-1 rounded-full bg-black-raw p-px px-2 text-sm text-white-raw">
       <Tooltip>
         <TooltipTrigger asChild>
           <UnauthPillAppLink to={{url: '/'}}>


### PR DESCRIPTION
The children of `<MainArea>` (which are all `<UnauthPill>` components) should accept pointer events, but since those divs are translated down from the actual `<MainArea>` we can remove pointer events from the main area itself. Because of the `translate-y` css, the main area is effectively 'empty space' on the page, used for aria correctness.