### PR TITLE
feat: Iterate on expand/collapse labels, and keep expanded during drag+drop

### DIFF
--- a/src/lib/components/DragDropPositionSurface.tsx
+++ b/src/lib/components/DragDropPositionSurface.tsx
@@ -1,18 +1,14 @@
 import {cva, cx} from 'cva';
-import {Fragment, useCallback, useContext, useEffect, useRef, useState} from 'react';
+import {Fragment, useCallback, useContext, useEffect, useRef} from 'react';
 import {twMerge} from 'tailwind-merge';
 import {useConfigContext} from 'toolbar/context/ConfigContext';
+import type {Coord} from 'toolbar/context/MousePositionContext';
+import {useMousePositionContext} from 'toolbar/context/MousePositionContext';
 import ReactMountContext from 'toolbar/context/ReactMountContext';
 import ShadowRootContext from 'toolbar/context/ShadowRootContext';
 import {useLocalStorage} from 'toolbar/hooks/useStorage';
 import type {Configuration} from 'toolbar/types/Configuration';
 import {hydratePlacement} from 'toolbar/utils/hydrateConfig';
-
-interface Coord {
-  x: number;
-  y: number;
-}
-type MaybeCoord = null | Coord;
 
 function hasGrabberAncestor(element: Element | null) {
   return element?.hasAttribute('data-grabber') || element?.closest('[data-grabber]') !== null;
@@ -54,7 +50,7 @@ function useDragDropPositionSurface({onPositionChange}: {onPositionChange: (posi
   const shadowRoot = useContext(ShadowRootContext);
   const reactMount = useContext(ReactMountContext);
 
-  const [mousePosition, setMousePosition] = useState<MaybeCoord>(null);
+  const [mousePosition, setMousePosition] = useMousePositionContext();
   const lastPositionRef = useRef<string>('unknown');
 
   useEffect(() => {
@@ -89,7 +85,7 @@ function useDragDropPositionSurface({onPositionChange}: {onPositionChange: (posi
     return () => {
       reactMount.removeEventListener('mousedown', handleMouseDown);
     };
-  }, [reactMount, onPositionChange, shadowRoot]);
+  }, [reactMount, onPositionChange, shadowRoot, setMousePosition]);
 
   return {mousePosition, lastPosition: lastPositionRef.current};
 }

--- a/src/lib/components/Navigation.tsx
+++ b/src/lib/components/Navigation.tsx
@@ -5,22 +5,24 @@ import {Fragment} from 'react';
 import type {MouseEvent} from 'react';
 import {NavLink, useLocation, useNavigate} from 'react-router-dom';
 import type {To} from 'react-router-dom';
+import ExternalLink from 'toolbar/components/base/ExternalLink';
 import Indicator from 'toolbar/components/base/Indicator';
 import {Menu, MenuItem} from 'toolbar/components/base/menu/Menu';
 import {Tooltip, TooltipTrigger, TooltipContent} from 'toolbar/components/base/tooltip/Tooltip';
 import IconClose from 'toolbar/components/icon/IconClose';
-import IconContract from 'toolbar/components/icon/IconContract';
-import IconExpand from 'toolbar/components/icon/IconExpand';
 import IconFlag from 'toolbar/components/icon/IconFlag';
 import IconIssues from 'toolbar/components/icon/IconIssues';
 import IconLock from 'toolbar/components/icon/IconLock';
 import IconMegaphone from 'toolbar/components/icon/IconMegaphone';
+import IconOpen from 'toolbar/components/icon/IconOpen';
+import IconPin from 'toolbar/components/icon/IconPin';
 import IconSentry from 'toolbar/components/icon/IconSentry';
 import IconSettings from 'toolbar/components/icon/IconSettings';
 import {useApiProxyInstance} from 'toolbar/context/ApiProxyContext';
 import {useConfigContext} from 'toolbar/context/ConfigContext';
 import {useFeatureFlagAdapterContext} from 'toolbar/context/FeatureFlagAdapterContext';
 import {useHiddenAppContext} from 'toolbar/context/HiddenAppContext';
+import {useMousePositionContext} from 'toolbar/context/MousePositionContext';
 import useNavigationExpansion from 'toolbar/hooks/useNavigationExpansion';
 import {DebugTarget} from 'toolbar/types/Configuration';
 import parsePlacement from 'toolbar/utils/parsePlacement';
@@ -72,6 +74,8 @@ const menuItemClass = cx('flex grow gap-1 whitespace-nowrap');
 
 export default function Navigation() {
   const [{placement}] = useConfigContext();
+  const [mousePosition] = useMousePositionContext();
+  const isMoving = Boolean(mousePosition);
   const {isExpanded, isPinned, setIsHovered, setIsPinned} = useNavigationExpansion();
   const {pathname} = useLocation();
   const navigate = useNavigate();
@@ -98,7 +102,7 @@ export default function Navigation() {
       onMouseOut={() => setIsHovered(false)}>
       <OptionsMenu isPinned={isPinned} setIsPinned={setIsPinned} />
 
-      <Transition show={isExpanded}>
+      <Transition show={isMoving || isExpanded}>
         <div
           className={cx(navClassName({isHorizontal}), 'p-0 transition duration-300 ease-in data-[closed]:opacity-0')}>
           <hr className={navGrabber({isHorizontal})} data-grabber />
@@ -176,11 +180,27 @@ function OptionsMenu({isPinned, setIsPinned}: {isPinned: boolean; setIsPinned: (
           <Tooltip>
             <TooltipTrigger asChild>
               <MenuItem className={menuItemClass} label="pin" onClick={() => setIsPinned(!isPinned)}>
-                {isPinned ? <IconContract size="sm" /> : <IconExpand size="sm" />}
-                {isPinned ? 'Contract' : 'Expand'}
+                <IconPin isSolid={isPinned} size="sm" />
+                {isPinned ? 'Pinned' : 'Un-Pinned'}
               </MenuItem>
             </TooltipTrigger>
-            <TooltipContent>{isPinned ? 'Shrink to save space' : 'Expand to show all tools'}</TooltipContent>
+            <TooltipContent>
+              {isPinned ? 'This panel will stay expanded' : 'This panel will shrink when not in use'}
+            </TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <MenuItem className={menuItemClass} label="help">
+                <ExternalLink
+                  to={{url: 'https://docs.sentry.io/product/sentry-toolbar/'}}
+                  className="contents text-inherit">
+                  <IconOpen size="sm" />
+                  Help
+                </ExternalLink>
+              </MenuItem>
+            </TooltipTrigger>
+            <TooltipContent className="whitespace-nowrap">Read the docs</TooltipContent>
           </Tooltip>
 
           <Tooltip>

--- a/src/lib/components/layouts/EdgeLayout.tsx
+++ b/src/lib/components/layouts/EdgeLayout.tsx
@@ -1,8 +1,8 @@
 import {cva, cx} from 'cva';
-import {Fragment} from 'react';
 import type {ReactNode} from 'react';
 import DragDropPositionSurface from 'toolbar/components/DragDropPositionSurface';
 import {useConfigContext} from 'toolbar/context/ConfigContext';
+import {MousePositionProvider} from 'toolbar/context/MousePositionContext';
 import type {Configuration} from 'toolbar/types/Configuration';
 
 interface Props {
@@ -70,10 +70,10 @@ export default function EdgeLayout({children}: Props) {
   const [{placement}] = useConfigContext();
 
   return (
-    <Fragment>
+    <MousePositionProvider>
       <div className={layoutClass({placement})}>{children}</div>
       <DragDropPositionSurface instanceName="EdgeLayout" />
-    </Fragment>
+    </MousePositionProvider>
   );
 }
 

--- a/src/lib/components/unauth/UnauthPill.tsx
+++ b/src/lib/components/unauth/UnauthPill.tsx
@@ -63,8 +63,6 @@ export default function UnauthPill({children}: Props) {
           <TooltipContent className="whitespace-nowrap">Read the docs</TooltipContent>
         </Tooltip>
 
-        <hr className={menuSeparator} />
-
         <Tooltip>
           <TooltipTrigger asChild>
             <MenuItem

--- a/src/lib/context/MousePositionContext.tsx
+++ b/src/lib/context/MousePositionContext.tsx
@@ -1,0 +1,19 @@
+import type {Dispatch, ReactNode, SetStateAction} from 'react';
+import {createContext, useContext, useState} from 'react';
+
+export interface Coord {
+  x: number;
+  y: number;
+}
+type MaybeCoord = null | Coord;
+
+const MousePositionContext = createContext<[MaybeCoord, Dispatch<SetStateAction<MaybeCoord>>]>([null, () => {}]);
+
+export function MousePositionProvider({children}: {children: ReactNode}) {
+  const state = useState<MaybeCoord>(null);
+  return <MousePositionContext.Provider value={state}>{children}</MousePositionContext.Provider>;
+}
+
+export function useMousePositionContext() {
+  return useContext(MousePositionContext);
+}


### PR DESCRIPTION
**Updated labels and tooltips**
<img width="246" alt="Screenshot 2025-07-02 at 3 36 39 PM" src="https://github.com/user-attachments/assets/c51f745f-16d1-4293-a193-e5129b7a54fa" />


**Before**
The mouse-position stuff in here also fixes and issue where it would collapse while drag+drop was happening, and it looked a bit weird.
<img width="341" alt="SCR-20250702-nvev" src="https://github.com/user-attachments/assets/aa76fba0-442f-42d9-8ae1-fb27e12af32e" />
