### PR TITLE
ci: Do not auto-publish the `latest` version to the CDN

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -15,15 +15,6 @@ targets:
       - path: /sentry-toolbar/{{version}}/
         metadata:
           cacheControl: 'public, max-age=60'
-  # Latest CDN Bundle Target
-  - name: gcs
-    id: 'browser-cdn-bundles'
-    includeNames: /.*\.js.*$/
-    bucket: sentry-js-sdk
-    paths:
-      - path: /sentry-toolbar/latest/
-        metadata:
-          cacheControl: 'public, max-age=60'
   # NPM package target
   - name: npm
     id: '@sentry/toolbar'


### PR DESCRIPTION
Before we were auto-publishing the `latest` tag to the CDN. This would be picked up by react users who have the `useSentryToolbar()` hook installed, and anyone who copy+pasted the CDN install instruction. I liked this before when it was early days, but it has the downside that if we publish a bad build everyone is affected.

So its time to turn that off, going forward we can manually publish `latest` as a safety measure.