### PR TITLE
chore(deps): bump react-router-dom to 7.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react": "19.2.3",
     "react-aria": "3.45.0",
     "react-dom": "19.2.3",
-    "react-router-dom": "7.14.0",
+    "react-router-dom": "7.18.0",
     "tailwind-merge": "3.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react": "19.2.3",
     "react-aria": "3.45.0",
     "react-dom": "19.2.3",
-    "react-router-dom": "7.11.0",
+    "react-router-dom": "7.14.0",
     "tailwind-merge": "3.4.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
       react-router-dom:
-        specifier: 7.11.0
-        version: 7.11.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 7.14.0
+        version: 7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tailwind-merge:
         specifier: 3.4.0
         version: 3.4.0
@@ -228,30 +228,6 @@ importers:
       vite-plugin-svgr:
         specifier: ^4.5.0
         version: 4.5.0(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.2(@types/node@25.3.3)(jiti@1.21.7)(yaml@2.8.2))
-
-  packages/toolbar:
-    devDependencies:
-      '@openfeature/web-sdk':
-        specifier: 1.7.2
-        version: 1.7.2(@openfeature/core@1.6.0)
-      '@sentry/vite-plugin':
-        specifier: 4.6.1
-        version: 4.6.1
-      '@types/react':
-        specifier: 19.2.7
-        version: 19.2.7
-      ts-node:
-        specifier: 10.9.2
-        version: 10.9.2(@types/node@25.3.3)(typescript@5.9.3)
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
-      vite:
-        specifier: 7.3.2
-        version: 7.3.2(@types/node@25.3.3)(jiti@1.21.7)(yaml@2.8.2)
-      vite-plugin-dts:
-        specifier: 4.5.4
-        version: 4.5.4(@types/node@25.3.3)(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.2(@types/node@25.3.3)(jiti@1.21.7)(yaml@2.8.2))
 
 packages:
 
@@ -4152,7 +4128,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   global-modules@2.0.0:
     resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
@@ -5718,15 +5694,15 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
-  react-router-dom@7.11.0:
-    resolution: {integrity: sha512-e49Ir/kMGRzFOOrYQBdoitq3ULigw4lKbAyKusnvtDu2t4dBX4AGYPrzNvorXmVuOyeakai6FUPW5MmibvVG8g==}
+  react-router-dom@7.14.0:
+    resolution: {integrity: sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@7.11.0:
-    resolution: {integrity: sha512-uI4JkMmjbWCZc01WVP2cH7ZfSzH91JAZUDd7/nIprDgWxBV1TkkmLToFh7EbMTcMak8URFRa2YoBL/W8GWnCTQ==}
+  react-router@7.14.0:
+    resolution: {integrity: sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -6829,7 +6805,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -7624,7 +7600,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10136,7 +10112,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10831,10 +10807,6 @@ snapshots:
       ms: 2.1.3
 
   debug@4.3.7:
-    dependencies:
-      ms: 2.1.3
-
-  debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
@@ -11751,7 +11723,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13537,13 +13509,13 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
-  react-router-dom@7.11.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  react-router-dom@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      react-router: 7.11.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react-router: 7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  react-router@7.11.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       cookie: 1.1.1
       react: 19.2.3
@@ -14530,7 +14502,7 @@ snapshots:
       '@volar/typescript': 2.4.28
       '@vue/language-core': 2.2.0(typescript@5.9.3)
       compare-versions: 6.1.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       kolorist: 1.8.0
       local-pkg: 1.1.2
       magic-string: 0.30.21

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
       react-router-dom:
-        specifier: 7.14.0
-        version: 7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 7.18.0
+        version: 7.18.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tailwind-merge:
         specifier: 3.4.0
         version: 3.4.0
@@ -5694,15 +5694,15 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
-  react-router-dom@7.14.0:
-    resolution: {integrity: sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==}
+  react-router-dom@7.18.0:
+    resolution: {integrity: sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@7.14.0:
-    resolution: {integrity: sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==}
+  react-router@7.18.0:
+    resolution: {integrity: sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -13509,13 +13509,13 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
-  react-router-dom@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  react-router-dom@7.18.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      react-router: 7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react-router: 7.18.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  react-router@7.18.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       cookie: 1.1.1
       react: 19.2.3


### PR DESCRIPTION
Bumps `react-router-dom` from 7.11.0 to 7.18.0 (latest 7.x) and refreshes the lockfile.

### Why
Started as a fix for the Semgrep finding behind REPLAY-929 / VULN-1933 — CVE-2026-34077 (GHSA-rxv8-25v2-qmq8), a DoS in react-router's vendored `turbo-stream` (fixed in 7.14.0). However, 7.14.0 itself carries two newer high-severity advisories that the `dependency-review` gate rejects:

| Advisory | Issue | Patched |
|---|---|---|
| CVE-2026-34077 / GHSA-rxv8-25v2-qmq8 | turbo-stream Single-Fetch serialization DoS | 7.14.0 |
| CVE-2026-42211 / GHSA-49rj-9fvp-4h2h | turbo-stream `TYPE_ERROR` arbitrary constructor → RCE | 7.14.2 |
| CVE-2026-42342 / GHSA-8x6r-g9mw-2r78 | DoS via unbounded path expansion in `__manifest` | 7.15.0 |

Going to the latest 7.x (**7.18.0**) clears all three in one bump and avoids landing on a version with a known advisory between 7.15 and 7.18.

### Reachability
All three are **React Router Framework Mode** issues (data router + server + Single Fetch / `__manifest`). The toolbar uses only `MemoryRouter` with component-based routes (`src/lib/components/AppRouter.tsx`) — no data router, loaders/actions, or server — so none of these paths are reachable here. `turbo-stream` is not even in the dependency tree. The `dependency-review` gate fails on the advisory regardless of reachability, so the bump is needed to get CI green and clear the finding.

### Verification
- `pnpm lint:types` — clean
- `pnpm test` — 134/134 pass
- `pnpm build` — builds `dist/toolbar.min.js` (the `vite:dts` TS4058 warning on `useToast`/`ToastContext` is pre-existing on `main`)

Linear: REPLAY-929, VULN-1933

🤖 Generated with [Claude Code](https://claude.com/claude-code)