### PR TITLE
fix: prepend organizationSlug to issue and user-feedback URLs in SentryAppLink (#339)

### DIFF
--- a/src/lib/components/base/SentryAppLink.tsx
+++ b/src/lib/components/base/SentryAppLink.tsx
@@ -14,12 +14,18 @@ export interface Props extends ComponentProps<typeof ExternalLink> {
 
 export default function SentryAppLink({children, className, to, onClick, ...props}: Props) {
   const [config] = useConfigContext();
+  const {organizationSlug} = config;
+
+  let urlPath = to.url;
+  if (organizationSlug && (urlPath.startsWith('/issues') || urlPath.startsWith('/user-feedback'))) {
+    urlPath = `/organizations/${organizationSlug}${urlPath}`;
+  }
 
   return (
     <ExternalLink
       {...props}
       to={{
-        url: `${getSentryWebOrigin(config)}${to.url}`,
+        url: `${getSentryWebOrigin(config)}${urlPath}`,
         query: to.query,
       }}
       onClick={onClick}

--- a/src/lib/components/base/SentryAppLink.tsx
+++ b/src/lib/components/base/SentryAppLink.tsx
@@ -17,7 +17,10 @@ export default function SentryAppLink({children, className, to, onClick, ...prop
   const {organizationSlug} = config;
 
   let urlPath = to.url;
-  if (organizationSlug && (urlPath.startsWith('/issues') || urlPath.startsWith('/user-feedback'))) {
+  if (
+    organizationSlug &&
+    (urlPath.startsWith('/issues') || urlPath.startsWith('/feedback') || urlPath.startsWith('/user-feedback'))
+  ) {
     urlPath = `/organizations/${organizationSlug}${urlPath}`;
   }
 


### PR DESCRIPTION
Fixes #339. When organizationSlug is configured on self-hosted Sentry instances, issue links and user-feedback links should be routed through /organizations/${organizationSlug}/issues/... rather than omitting the org path.