### PR TITLE
fix: fall back to pathname for page filtering

### DIFF
--- a/src/lib/hooks/useCurrentSentryTransactionName.spec.ts
+++ b/src/lib/hooks/useCurrentSentryTransactionName.spec.ts
@@ -1,0 +1,50 @@
+import type {Scope} from '@sentry/core';
+import {renderHook} from '@testing-library/react';
+import useCurrentSentryTransactionName from 'toolbar/hooks/useCurrentSentryTransactionName';
+import useSentryClientAndScope from 'toolbar/hooks/useSentryClientAndScope';
+
+jest.mock('toolbar/hooks/useSentryClientAndScope');
+
+const mockUseSentryClientAndScope = jest.mocked(useSentryClientAndScope);
+
+describe('useCurrentSentryTransactionName', () => {
+  const originalLocation = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/projects/123/issues');
+    mockUseSentryClientAndScope.mockReturnValue({scope: undefined, client: undefined});
+  });
+
+  afterEach(() => {
+    window.history.replaceState({}, '', originalLocation);
+    jest.clearAllMocks();
+  });
+
+  it('uses the current pathname when the Sentry SDK is unavailable', () => {
+    const {result} = renderHook(() => useCurrentSentryTransactionName());
+
+    expect(result.current).toBe('/projects/*/issues');
+  });
+
+  it('prefers the current Sentry transaction name', () => {
+    const scope = {
+      getScopeData: () => ({transactionName: '/organizations/456/settings'}),
+    } as unknown as Scope;
+    mockUseSentryClientAndScope.mockReturnValue({scope, client: undefined});
+
+    const {result} = renderHook(() => useCurrentSentryTransactionName());
+
+    expect(result.current).toBe('/organizations/*/settings');
+  });
+
+  it('uses the current pathname when the Sentry transaction name is empty', () => {
+    const scope = {
+      getScopeData: () => ({transactionName: ''}),
+    } as unknown as Scope;
+    mockUseSentryClientAndScope.mockReturnValue({scope, client: undefined});
+
+    const {result} = renderHook(() => useCurrentSentryTransactionName());
+
+    expect(result.current).toBe('/projects/*/issues');
+  });
+});

--- a/src/lib/hooks/useCurrentSentryTransactionName.ts
+++ b/src/lib/hooks/useCurrentSentryTransactionName.ts
@@ -7,7 +7,9 @@ export default function useCurrentSentryTransactionName() {
   const [{transactionToSearchTerm}] = useConfigContext();
   const {scope, client} = useSentryClientAndScope();
 
-  const [transactionName, setTransactionName] = useState(scope?.getScopeData().transactionName ?? '');
+  const [transactionName, setTransactionName] = useState(
+    scope?.getScopeData().transactionName || window.location.pathname
+  );
 
   useEffect(() => {
     if (client) {


### PR DESCRIPTION
## Summary

- fall back to `window.location.pathname` when no Sentry transaction name is available
- keep active Sentry transactions and navigation-span updates as the preferred source
- pass the fallback through the configured transaction search-term normalizer

## Testing

- `pnpm test --runInBand` (137 tests)
- `pnpm lint:types`
- `pnpm exec eslint --report-unused-disable-directives src/lib/hooks/useCurrentSentryTransactionName.ts src/lib/hooks/useCurrentSentryTransactionName.spec.ts`
- `pnpm build:lib`
- `git diff --check`

Closes #338