### PR TITLE
fix(a11y): add missing alt text to AvatarIcon image

### DIFF
--- a/src/lib/components/avatar/AvatarIcon.tsx
+++ b/src/lib/components/avatar/AvatarIcon.tsx
@@ -32,7 +32,7 @@ export default function AvatarIcon({name, avatarUrl, type, tooltip, size = 'sm'}
     <Tooltip>
       <TooltipTrigger>
         {avatarUrl ? (
-          <img className={cx(imageClassName({size, type}))} src={avatarUrl} />
+          <img className={cx(imageClassName({size, type}))} src={avatarUrl} alt={name} />
         ) : (
           <span className={cx(imageClassName({size, type}))} style={{backgroundColor: getAvatarColor(name)}}>
             {getAvatarInitials(name)}


### PR DESCRIPTION
The <img> element in AvatarIcon.tsx was missing an alt attribute, which is
a basic accessibility issue for screen readers. This uses the existing
`name` prop as the alt text, since it's already used elsewhere in the
component (e.g. to render initials as a fallback).

This is the only <img> tag in the codebase, so no other places needed changes.