### PR TITLE
docs: fix typo in diagram and double space in toolbar README

### DIFF
--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -70,7 +70,7 @@ flowchart TB
     window.handleParent --> originIsReferrer{"messageEvent.origin === referrer?"}
     originIsReferrer -- true --> checkParentMessage{"messageEvent.data.message?"}
     checkParentMessage -- "request-login" --> window.open["window.open"]    
-    checkParentMessage -- "requets-logout" --> clearCookie{"document.cookie = ''"}
+    checkParentMessage -- "request-logout" --> clearCookie{"document.cookie = ''"}
     clearCookie --> opener.postMessage2["opener.postMessage('stale')"]
     
     parentPost -- enables --> port.handleMessage(("port.handleMessage"))

--- a/packages/toolbar/README.md
+++ b/packages/toolbar/README.md
@@ -14,7 +14,7 @@ Bring critical Sentry insights and tools directly into your web app for easier t
 
 ## Usage
 
-To use the Sentry Toolbar, install `@sentry/toolbar` into your React project and include the hook in  a React component that wraps your app.
+To use the Sentry Toolbar, install `@sentry/toolbar` into your React project and include the hook in a React component that wraps your app.
 
 ```javascript
 import {useSentryToolbar} from '@sentry/toolbar';


### PR DESCRIPTION
- docs/diagrams.md: fixed "requets-logout" -> "request-logout" in the
  mermaid diagram, matching the actual message string used in
  src/lib/utils/ApiProxy.ts.
- packages/toolbar/README.md: removed a double space.

Docs only, no functional changes.